### PR TITLE
feat: add WebSocket endpoint for real-time game communication

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ ktor-server-core = { group = "io.ktor", name = "ktor-server-core", version.ref =
 ktor-server-netty = { group = "io.ktor", name = "ktor-server-netty", version.ref = "ktor" }
 ktor-server-content-negotiation = { group = "io.ktor", name = "ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-server-websockets = { group = "io.ktor", name = "ktor-server-websockets", version.ref = "ktor" }
 ktor-server-test-host = { group = "io.ktor", name = "ktor-server-test-host", version.ref = "ktor" }
 
 # Serialization & logging

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.netty)
     implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.server.websockets)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.logback.classic)
 

--- a/server/src/main/kotlin/com/example/server/Application.kt
+++ b/server/src/main/kotlin/com/example/server/Application.kt
@@ -13,6 +13,10 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
+import io.ktor.server.websocket.WebSockets
+import io.ktor.server.websocket.webSocket
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
 
 fun main() {
     embeddedServer(Netty, port = Constants.DEFAULT_PORT) {
@@ -25,12 +29,24 @@ fun Application.configurePlugins() {
     install(ContentNegotiation) {
         json()
     }
+    // Aktiviert WebSocket-Support im Server
+    install(WebSockets)
 }
 
 fun Application.configureRoutes() {
     routing {
+        //REST Endpoint
         get(ApiRoutes.HEALTH) {
             call.respond(HealthResponse(status = "UP"))
+        }
+
+        // WebSocket-Endpoint
+        webSocket(ApiRoutes.GAME) {
+            for (frame in incoming) { // Wartet auf eingehende Nachrichten
+                if (frame is Frame.Text) { // Nur Text-Nachrichten verarbeiten
+                    send(Frame.Text("Echo: ${frame.readText()}")) // Antwort zurueckschicken
+                }
+            }
         }
     }
 }

--- a/server/src/main/kotlin/com/example/server/Application.kt
+++ b/server/src/main/kotlin/com/example/server/Application.kt
@@ -35,7 +35,7 @@ fun Application.configurePlugins() {
 
 fun Application.configureRoutes() {
     routing {
-        //REST Endpoint
+        // REST Endpoint
         get(ApiRoutes.HEALTH) {
             call.respond(HealthResponse(status = "UP"))
         }

--- a/shared/src/main/kotlin/com/example/shared/ApiRoutes.kt
+++ b/shared/src/main/kotlin/com/example/shared/ApiRoutes.kt
@@ -3,4 +3,5 @@ package com.example.shared
 /** Centralized API route constants used by both server and android-app. */
 object ApiRoutes {
     const val HEALTH = "/health"
+    const val GAME = "/game"
 }


### PR DESCRIPTION
Adds WebSocket support to the server with a simple endpoint at `/game`.
Changes:
- Added `ktor-server-websockets` dependency
- Installed the WebSockets plugin in the server
- Added `/game` WebSocket endpoint that echoes messages back
- Added `GAME` route constant in shared ApiRoutes