### PR TITLE
fix: Rename duck to goose

### DIFF
--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/enums/AnimalType.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/enums/AnimalType.kt
@@ -4,7 +4,7 @@ enum class AnimalType(
     val points: Int,
 ) {
     CHICKEN(10),
-    DUCK(40),
+    GOOSE(40),
     CAT(90),
     DOG(180),
     SHEEP(250),


### PR DESCRIPTION
The goose animal card was previously mistaken to be a duck.
The confusion was caused by the two species similar phenotype.