### PR TITLE
Feat/server minimal game logic

### DIFF
--- a/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
@@ -1,0 +1,14 @@
+package at.aau.kuhhandel.server.model
+
+import at.aau.kuhhandel.shared.model.GameState
+
+/**
+ * One running game session on the server
+ *
+ * ID to identify the game (maybe not as neccesary in our case)
+ * Has the current GameState from the shared module
+ */
+data class GameSession(
+    val sessionId: String,
+    val gameState: GameState,
+)

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameManager.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameManager.kt
@@ -1,0 +1,93 @@
+package at.aau.kuhhandel.server.service
+
+import at.aau.kuhhandel.server.model.GameSession
+import at.aau.kuhhandel.shared.enums.AnimalType
+import at.aau.kuhhandel.shared.enums.GamePhase
+import at.aau.kuhhandel.shared.model.AnimalCard
+import at.aau.kuhhandel.shared.model.AnimalDeck
+import at.aau.kuhhandel.shared.model.GameState
+import java.util.UUID
+
+/**
+ * Manages the Game Sessions (Phase 2 - minimal logic)
+ */
+class GameManager {
+    // Stores all active sessions
+    private val sessions: MutableMap<String, GameSession> = mutableMapOf()
+
+    /**
+     * Creates a simple test game with a small deck
+     */
+    fun createTestGame(): GameSession {
+        val testDeck =
+            AnimalDeck(
+                mutableListOf(
+                    AnimalCard(id = "1", type = AnimalType.COW),
+                    AnimalCard(id = "2", type = AnimalType.DOG),
+                    AnimalCard(id = "3", type = AnimalType.CAT),
+                ),
+            )
+
+        val gameState =
+            GameState(
+                phase = GamePhase.RUNNING,
+                deck = testDeck,
+                currentFaceUpCard = null,
+                currentPlayerIndex = 0,
+                players = emptyList(),
+            )
+
+        val session =
+            GameSession(
+                sessionId = UUID.randomUUID().toString(),
+                gameState = gameState,
+            )
+
+        sessions[session.sessionId] = session
+        return session
+    }
+
+    /**
+     * Returns a session by ID
+     */
+    fun getSession(sessionId: String): GameSession? {
+        return sessions[sessionId]
+    }
+
+    /**
+     * Reveals the next card in the deck
+     */
+    fun revealNextCard(sessionId: String): GameState? {
+        val session = sessions[sessionId] ?: return null
+        val currentState = session.gameState
+
+        // If deck empty → finish game
+        if (currentState.deck.isEmpty()) {
+            val finishedState =
+                currentState.copy(
+                    phase = GamePhase.FINISHED,
+                    currentFaceUpCard = null,
+                )
+
+            sessions[sessionId] = session.copy(gameState = finishedState)
+            return finishedState
+        }
+
+        // Draw next card
+        val nextCard = currentState.deck.drawTopCard()
+
+        val updatedState =
+            currentState.copy(
+                currentFaceUpCard = nextCard,
+                phase =
+                    if (currentState.deck.isEmpty()) {
+                        GamePhase.FINISHED
+                    } else {
+                        currentState.phase
+                    },
+            )
+
+        sessions[sessionId] = session.copy(gameState = updatedState)
+        return updatedState
+    }
+}

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameManagerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameManagerTest.kt
@@ -1,0 +1,85 @@
+package at.aau.kuhhandel.server.service
+
+import at.aau.kuhhandel.shared.enums.GamePhase
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class GameManagerTest {
+    @Test
+    fun test_createTestGame_initialStateIsCorrect() {
+        val manager = GameManager()
+
+        val session = manager.createTestGame()
+
+        // Game should start running with no revealed card
+        assertEquals(GamePhase.RUNNING, session.gameState.phase)
+        assertNull(session.gameState.currentFaceUpCard)
+
+        // Test deck has 3 cards
+        assertEquals(3, session.gameState.deck.size())
+    }
+
+    @Test
+    fun test_getSession_returnsCorrectSession() {
+        val manager = GameManager()
+        val session = manager.createTestGame()
+
+        val loadedSession = manager.getSession(session.sessionId)
+
+        // Retrieved session should match the original
+        assertNotNull(loadedSession)
+        assertEquals(session.sessionId, loadedSession.sessionId)
+    }
+
+    @Test
+    fun test_revealNextCard_revealsCard() {
+        val manager = GameManager()
+        val session = manager.createTestGame()
+
+        val updatedState = manager.revealNextCard(session.sessionId)
+
+        // A card should now be visible
+        assertNotNull(updatedState)
+        assertNotNull(updatedState.currentFaceUpCard)
+        assertEquals(GamePhase.RUNNING, updatedState.phase)
+    }
+
+    @Test
+    fun test_revealNextCard_reducesDeckSize() {
+        val manager = GameManager()
+        val session = manager.createTestGame()
+
+        val beforeSize = session.gameState.deck.size()
+        val updatedState = manager.revealNextCard(session.sessionId)
+        val afterSize = updatedState?.deck?.size()
+
+        // Deck size should decrease by 1
+        assertEquals(beforeSize - 1, afterSize)
+    }
+
+    @Test
+    fun test_revealNextCard_finishesGame_whenDeckEmpty() {
+        val manager = GameManager()
+        val session = manager.createTestGame()
+
+        // Reveal all cards
+        manager.revealNextCard(session.sessionId)
+        manager.revealNextCard(session.sessionId)
+        val finalState = manager.revealNextCard(session.sessionId)
+
+        assertNotNull(finalState)
+        assertEquals(GamePhase.FINISHED, finalState.phase)
+    }
+
+    @Test
+    fun test_revealNextCard_returnsNull_forInvalidSession() {
+        val manager = GameManager()
+
+        val result = manager.revealNextCard("invalid-id")
+
+        // Invalid session should return null
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
This PR includes minimal server side game logic as well as small unit tests for coverage.

Changes are:
- added GameSession to represent a running game  instance
- added GameManager to manage these sessions and has a basic game flow
- Unit Tests for GameManager

Note: this is a minimal implementation to have a small foundation. More logic needs to be added as we are headed into Sprint 2