### PR TITLE
config: adjust Sonar coverage configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,10 @@ configure<SonarExtension> {
             ).joinToString(","),
         )
 
-        property("sonar.java.binaries", "**/build/classes/kotlin/main,**/build/tmp/kotlin-classes/debug")
+        property(
+            "sonar.java.binaries",
+            "**/build/classes/kotlin/main,**/build/tmp/kotlin-classes/debug",
+        )
         property("sonar.kotlin.source.version", "2.0")
         property("sonar.coverage.jacoco.xmlReportPaths", "**/build/reports/jacoco/**/*.xml")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,14 @@ configure<SonarExtension> {
             "**/build/classes/kotlin/main,**/build/tmp/kotlin-classes/debug",
         )
         property("sonar.kotlin.source.version", "2.0")
-        property("sonar.coverage.jacoco.xmlReportPaths", "**/build/reports/jacoco/**/*.xml")
+        property(
+            "sonar.coverage.jacoco.xmlReportPaths",
+            listOf(
+                "server/build/reports/jacoco/test/jacocoTestReport.xml",
+                "shared/build/reports/jacoco/test/jacocoTestReport.xml",
+                "app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml",
+            ).joinToString(","),
+        )
     }
 }
 


### PR DESCRIPTION
This PR attempts to resolve missing coverage reporting for the app module in SonarCloud.
Needs verification after merge.