### PR TITLE
config: fix missing app source folder in SonarCloud

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,8 @@ android {
     buildFeatures {
         compose = true
     }
+
+    sourceSets["main"].java.srcDirs("src/main/kotlin")
 }
 
 // Kotlin 2.3.20: kotlinOptions is removed; use the compilerOptions DSL instead.


### PR DESCRIPTION
Attempts to fix #79.
Expose Kotlin source directory in the app module so SonarCloud can detect it.