### PR TITLE
feat: add GitHub Actions workflow to block PRs from staging to main

### DIFF
--- a/.github/workflows/block-staging-to-main.yml
+++ b/.github/workflows/block-staging-to-main.yml
@@ -1,0 +1,29 @@
+name: Block Staging To Main
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: block-staging-to-main-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate-pr-source:
+    name: Validate PR source branch
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fail when the PR source branch is staging
+        shell: bash
+        run: |
+          if [ "${{ github.head_ref }}" = "staging" ]; then
+            echo "Pull requests from staging to main are not allowed."
+            exit 1
+          fi
+
+          echo "Source branch '${{ github.head_ref }}' is allowed."

--- a/.github/workflows/block-staging-to-main.yml
+++ b/.github/workflows/block-staging-to-main.yml
@@ -1,4 +1,4 @@
-name: Block Staging To Main
+name: Block Staging Merge To Main
 
 on:
   pull_request:

--- a/.github/workflows/block-staging-to-main.yml
+++ b/.github/workflows/block-staging-to-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Fail when the PR source branch is staging
         shell: bash
         run: |
-          if [ "${{ github.head_ref }}" = "staging" ]; then
+          if [ "${{ github.head_ref }}" = "staging" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
             echo "Pull requests from staging to main are not allowed."
             exit 1
           fi


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to prevent pull requests from the `staging` branch into the `main` branch. This helps enforce branch protection policies and ensures that only appropriate branches can be merged into `main`.

Branch protection:

* Added a new workflow file `.github/workflows/block-staging-to-main.yml` that blocks pull requests where the source branch is `staging` and the target branch is `main`, failing the workflow if such a PR is opened.