### PR TITLE
feat: add game phases

### DIFF
--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameManager.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameManager.kt
@@ -9,14 +9,14 @@ import at.aau.kuhhandel.shared.model.GameState
 import java.util.UUID
 
 /**
- * Manages the Game Sessions (Phase 2 - minimal logic)
+ * Manages the game sessions (minimal logic).
  */
 class GameManager {
     // Stores all active sessions
     private val sessions: MutableMap<String, GameSession> = mutableMapOf()
 
     /**
-     * Creates a simple test game with a small deck
+     * Creates a simple test game with a small deck.
      */
     fun createTestGame(): GameSession {
         val testDeck =
@@ -30,7 +30,7 @@ class GameManager {
 
         val gameState =
             GameState(
-                phase = GamePhase.RUNNING,
+                phase = GamePhase.PLAYER_TURN,
                 deck = testDeck,
                 currentFaceUpCard = null,
                 currentPlayerIndex = 0,
@@ -48,18 +48,18 @@ class GameManager {
     }
 
     /**
-     * Returns a session by ID
+     * Returns a session by ID.
      */
     fun getSession(sessionId: String): GameSession? = sessions[sessionId]
 
     /**
-     * Reveals the next card in the deck
+     * Reveals the next card in the deck.
      */
     fun revealNextCard(sessionId: String): GameState? {
         val session = sessions[sessionId] ?: return null
         val currentState = session.gameState
 
-        // If deck empty → finish game
+        // If the deck is already empty, finish the game.
         if (currentState.deck.isEmpty()) {
             val finishedState =
                 currentState.copy(
@@ -71,18 +71,13 @@ class GameManager {
             return finishedState
         }
 
-        // Draw next card
+        // Draw the next card from the deck.
         val nextCard = currentState.deck.drawTopCard()
 
         val updatedState =
             currentState.copy(
                 currentFaceUpCard = nextCard,
-                phase =
-                    if (currentState.deck.isEmpty()) {
-                        GamePhase.FINISHED
-                    } else {
-                        currentState.phase
-                    },
+                phase = GamePhase.PLAYER_TURN,
             )
 
         sessions[sessionId] = session.copy(gameState = updatedState)

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameManagerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameManagerTest.kt
@@ -13,11 +13,8 @@ class GameManagerTest {
 
         val session = manager.createTestGame()
 
-        // Game should start running with no revealed card
-        assertEquals(GamePhase.RUNNING, session.gameState.phase)
+        assertEquals(GamePhase.PLAYER_TURN, session.gameState.phase)
         assertNull(session.gameState.currentFaceUpCard)
-
-        // Test deck has 3 cards
         assertEquals(3, session.gameState.deck.size())
     }
 
@@ -28,7 +25,6 @@ class GameManagerTest {
 
         val loadedSession = manager.getSession(session.sessionId)
 
-        // Retrieved session should match the original
         assertNotNull(loadedSession)
         assertEquals(session.sessionId, loadedSession.sessionId)
     }
@@ -40,10 +36,9 @@ class GameManagerTest {
 
         val updatedState = manager.revealNextCard(session.sessionId)
 
-        // A card should now be visible
         assertNotNull(updatedState)
         assertNotNull(updatedState.currentFaceUpCard)
-        assertEquals(GamePhase.RUNNING, updatedState.phase)
+        assertEquals(GamePhase.PLAYER_TURN, updatedState.phase)
     }
 
     @Test
@@ -55,22 +50,51 @@ class GameManagerTest {
         val updatedState = manager.revealNextCard(session.sessionId)
         val afterSize = updatedState?.deck?.size()
 
-        // Deck size should decrease by 1
         assertEquals(beforeSize - 1, afterSize)
     }
 
     @Test
-    fun test_revealNextCard_finishesGame_whenDeckEmpty() {
+    fun test_revealNextCard_updatesStoredSessionState() {
         val manager = GameManager()
         val session = manager.createTestGame()
 
-        // Reveal all cards
+        manager.revealNextCard(session.sessionId)
+        val loadedSession = manager.getSession(session.sessionId)
+
+        assertNotNull(loadedSession)
+        assertNotNull(loadedSession.gameState.currentFaceUpCard)
+        assertEquals(2, loadedSession.gameState.deck.size())
+        assertEquals(GamePhase.PLAYER_TURN, loadedSession.gameState.phase)
+    }
+
+    @Test
+    fun test_revealNextCard_lastCardDoesNotImmediatelyFinishGame() {
+        val manager = GameManager()
+        val session = manager.createTestGame()
+
+        manager.revealNextCard(session.sessionId)
+        manager.revealNextCard(session.sessionId)
+        val stateAfterLastCard = manager.revealNextCard(session.sessionId)
+
+        assertNotNull(stateAfterLastCard)
+        assertNotNull(stateAfterLastCard.currentFaceUpCard)
+        assertEquals(GamePhase.PLAYER_TURN, stateAfterLastCard.phase)
+        assertEquals(0, stateAfterLastCard.deck.size())
+    }
+
+    @Test
+    fun test_revealNextCard_finishesGame_whenDeckAlreadyEmpty() {
+        val manager = GameManager()
+        val session = manager.createTestGame()
+
+        manager.revealNextCard(session.sessionId)
         manager.revealNextCard(session.sessionId)
         manager.revealNextCard(session.sessionId)
         val finalState = manager.revealNextCard(session.sessionId)
 
         assertNotNull(finalState)
         assertEquals(GamePhase.FINISHED, finalState.phase)
+        assertNull(finalState.currentFaceUpCard)
     }
 
     @Test
@@ -79,7 +103,6 @@ class GameManagerTest {
 
         val result = manager.revealNextCard("invalid-id")
 
-        // Invalid session should return null
         assertNull(result)
     }
 }

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/enums/GamePhase.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/enums/GamePhase.kt
@@ -2,6 +2,11 @@ package at.aau.kuhhandel.shared.enums
 
 enum class GamePhase {
     NOT_STARTED,
-    RUNNING,
+
+    PLAYER_TURN,
+
+    AUCTION,
+    ROUND_END,
+
     FINISHED,
 }

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/AuctionState.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/AuctionState.kt
@@ -1,0 +1,12 @@
+package at.aau.kuhhandel.shared.model
+
+data class AuctionState(
+    // The card that is currently being auctioned
+    val auctionCard: AnimalCard,
+    // Current highest bid
+    val highestBid: Int = 0,
+    // ID of the player with the highest bid
+    val highestBidderId: String? = null,
+    // Can later be used for countdown / closing logic
+    val isClosed: Boolean = false,
+)

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
@@ -8,4 +8,8 @@ data class GameState(
     val currentFaceUpCard: AnimalCard? = null,
     val currentPlayerIndex: Int = 0,
     val players: List<PlayerState> = emptyList(),
+    // Active auction state, null if no auction is running
+    val auctionState: AuctionState? = null,
+    // Active trade state, null if no trade is running
+    val tradeState: TradeState? = null,
 )

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/TradeState.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/TradeState.kt
@@ -1,0 +1,18 @@
+package at.aau.kuhhandel.shared.model
+
+import at.aau.kuhhandel.shared.enums.AnimalType
+
+data class TradeState(
+    // Player who started the trade
+    val initiatingPlayerId: String,
+    // Player who was challenged
+    val challengedPlayerId: String,
+    // Animal type that is requested in the trade
+    val requestedAnimalType: AnimalType,
+    // Initial money offer
+    val offeredMoney: Int = 0,
+    // Optional counter offer from the challenged player
+    val counterOfferedMoney: Int? = null,
+    // Can later be used to mark the trade as finished
+    val isResolved: Boolean = false,
+)

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/AuctionStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/AuctionStateTest.kt
@@ -1,0 +1,20 @@
+package at.aau.kuhhandel.shared.model
+
+import at.aau.kuhhandel.shared.enums.AnimalType
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class AuctionStateTest {
+    @Test
+    fun test_defaultAuctionState() {
+        val card = AnimalCard(id = "1", type = AnimalType.COW)
+        val state = AuctionState(auctionCard = card)
+
+        assertEquals(card, state.auctionCard)
+        assertEquals(0, state.highestBid)
+        assertNull(state.highestBidderId)
+        assertFalse(state.isClosed)
+    }
+}

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/GameStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/GameStateTest.kt
@@ -16,5 +16,7 @@ class GameStateTest {
         assertNull(state.currentFaceUpCard)
         assertTrue(state.players.isEmpty())
         assertTrue(state.deck.isEmpty())
+        assertNull(state.auctionState)
+        assertNull(state.tradeState)
     }
 }

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/TradeStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/TradeStateTest.kt
@@ -1,0 +1,26 @@
+package at.aau.kuhhandel.shared.model
+
+import at.aau.kuhhandel.shared.enums.AnimalType
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class TradeStateTest {
+    @Test
+    fun test_defaultTradeState() {
+        val state =
+            TradeState(
+                initiatingPlayerId = "p1",
+                challengedPlayerId = "p2",
+                requestedAnimalType = AnimalType.COW,
+            )
+
+        assertEquals("p1", state.initiatingPlayerId)
+        assertEquals("p2", state.challengedPlayerId)
+        assertEquals(AnimalType.COW, state.requestedAnimalType)
+        assertEquals(0, state.offeredMoney)
+        assertNull(state.counterOfferedMoney)
+        assertFalse(state.isResolved)
+    }
+}


### PR DESCRIPTION
This PR includes the following changes:

In GamePhase RUNNING was removed and replaced by PLAYER_TURN, AUCTION, TRADE, ROUND_END, FINISHED as RUNNING was too vague for our game
Added new state classes: AuctionState & Tradestate, these were also added to GameState
Update in GameManager as RUNNING was removed to work with the new phases
adjusted tests for more coverage
smaller changes to comments etc
Reasons for changes:

Improves clarity of the game flow
Prepares the codebase for implementing auction and trade logic
Avoids ambiguous states like RUNNING
Increases test coverage for shared & server models