### PR TITLE
test: update app tests to use JUnit 5 and improve coverage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,6 +100,10 @@ dependencies {
     debugImplementation(libs.androidx.ui.tooling)
 }
 
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
 tasks.register<JacocoReport>("jacocoTestReport") {
     dependsOn("testDebugUnitTest")
 

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/NetworkClientFactoryTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/NetworkClientFactoryTest.kt
@@ -1,0 +1,15 @@
+package at.aau.kuhhandel.app.network
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+class NetworkClientFactoryTest {
+    @Test
+    fun `create returns a client`() {
+        val client = NetworkClientFactory.create()
+
+        assertNotNull(client)
+
+        client.close()
+    }
+}

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/PingServiceTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/PingServiceTest.kt
@@ -8,7 +8,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.runBlocking
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertTrue
 
 class PingServiceTest {


### PR DESCRIPTION
Improves app module coverage to reach SonarCloud threshold.

**Changes:**
- Enabled JUnit 5 for the app module.
- Migrated existing tests from JUnit 4 to JUnit 5.
- Added a NetworkClientFactory test.