### PR TITLE
Feat/round flow state machine

### DIFF
--- a/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
@@ -1,15 +1,14 @@
 package at.aau.kuhhandel.server.model
 
-import at.aau.kuhhandel.shared.enums.AnimalType
-import at.aau.kuhhandel.shared.enums.GamePhase
-import at.aau.kuhhandel.shared.model.AnimalCard
-import at.aau.kuhhandel.shared.model.AnimalDeck
+import at.aau.kuhhandel.server.service.GameCommand
+import at.aau.kuhhandel.server.service.GameStateMachine
 import at.aau.kuhhandel.shared.model.GameState
 import at.aau.kuhhandel.shared.model.PlayerState
 
 class GameSession(
     val gameId: String,
     val playerId: String,
+    private val stateMachine: GameStateMachine = GameStateMachine(),
 ) {
     // Each session manages its own current game state
     var gameState: GameState =
@@ -20,25 +19,7 @@ class GameSession(
      * Starts a game with a simple initial deck.
      */
     fun startGame(): GameState {
-        val initialDeck =
-            AnimalDeck(
-                listOf(
-                    AnimalCard(id = "1", type = AnimalType.COW),
-                    AnimalCard(id = "2", type = AnimalType.DOG),
-                    AnimalCard(id = "3", type = AnimalType.CAT),
-                ),
-            )
-
-        gameState =
-            gameState.copy(
-                phase = GamePhase.PLAYER_TURN,
-                deck = initialDeck,
-                currentFaceUpCard = null,
-                currentPlayerIndex = 0,
-                auctionState = null,
-                tradeState = null,
-            )
-
+        gameState = stateMachine.apply(gameState, GameCommand.StartGame)
         return gameState
     }
 
@@ -46,30 +27,7 @@ class GameSession(
      * Reveals the next card from the deck.
      */
     fun revealNextCard(): GameState {
-        val currentState = gameState
-
-        if (currentState.deck.isEmpty()) {
-            gameState =
-                currentState.copy(
-                    phase = GamePhase.FINISHED,
-                    currentFaceUpCard = null,
-                    auctionState = null,
-                    tradeState = null,
-                )
-            return gameState
-        }
-
-        val (nextCard, updatedDeck) = currentState.deck.drawTopCard()
-
-        gameState =
-            currentState.copy(
-                deck = updatedDeck,
-                currentFaceUpCard = nextCard,
-                phase = GamePhase.PLAYER_TURN,
-                auctionState = null,
-                tradeState = null,
-            )
-
+        gameState = stateMachine.apply(gameState, GameCommand.RevealCard)
         return gameState
     }
 }

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
@@ -30,4 +30,23 @@ class GameSession(
         gameState = stateMachine.apply(gameState, GameCommand.RevealCard)
         return gameState
     }
+
+    fun chooseAuction(): GameState {
+        gameState = stateMachine.apply(gameState, GameCommand.ChooseAuction)
+        return gameState
+    }
+
+    fun chooseTrade(challengedPlayerId: String): GameState {
+        gameState =
+            stateMachine.apply(
+                gameState,
+                GameCommand.ChooseTrade(challengedPlayerId),
+            )
+        return gameState
+    }
+
+    fun finishRound(): GameState {
+        gameState = stateMachine.apply(gameState, GameCommand.FinishRound)
+        return gameState
+    }
 }

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameCommand.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameCommand.kt
@@ -1,0 +1,18 @@
+package at.aau.kuhhandel.server.service
+
+/**
+ * Server-side commands that move a game from one deterministic state to the next.
+ */
+sealed interface GameCommand {
+    data object StartGame : GameCommand
+
+    data object RevealCard : GameCommand
+
+    data object ChooseAuction : GameCommand
+
+    data class ChooseTrade(
+        val challengedPlayerId: String,
+    ) : GameCommand
+
+    data object FinishRound : GameCommand
+}

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameService.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameService.kt
@@ -57,6 +57,24 @@ class GameService {
         return updatedState
     }
 
+    fun chooseAuction(gameId: String): GameState? {
+        val session = sessions[gameId] ?: return null
+        return session.chooseAuction()
+    }
+
+    fun chooseTrade(
+        gameId: String,
+        challengedPlayerId: String,
+    ): GameState? {
+        val session = sessions[gameId] ?: return null
+        return session.chooseTrade(challengedPlayerId)
+    }
+
+    fun finishRound(gameId: String): GameState? {
+        val session = sessions[gameId] ?: return null
+        return session.finishRound()
+    }
+
     /**
      * Generates a unique 5-digit game code.
      */

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
@@ -1,0 +1,170 @@
+package at.aau.kuhhandel.server.service
+
+import at.aau.kuhhandel.shared.enums.AnimalType
+import at.aau.kuhhandel.shared.enums.GamePhase
+import at.aau.kuhhandel.shared.model.AnimalCard
+import at.aau.kuhhandel.shared.model.AnimalDeck
+import at.aau.kuhhandel.shared.model.AuctionState
+import at.aau.kuhhandel.shared.model.GameState
+import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.TradeState
+
+class GameStateMachine {
+    fun apply(
+        state: GameState,
+        command: GameCommand,
+    ): GameState =
+        when (command) {
+            GameCommand.StartGame -> startGame(state)
+            GameCommand.RevealCard -> revealCard(state)
+            GameCommand.ChooseAuction -> chooseAuction(state)
+            is GameCommand.ChooseTrade -> chooseTrade(state, command)
+            GameCommand.FinishRound -> finishRound(state)
+        }
+
+    private fun startGame(state: GameState): GameState {
+        check(state.phase == GamePhase.NOT_STARTED) {
+            "Cannot start a game during phase ${state.phase}"
+        }
+
+        return state.copy(
+            phase = GamePhase.PLAYER_TURN,
+            roundNumber = 1,
+            deck = createPrototypeDeck(),
+            currentFaceUpCard = null,
+            currentPlayerIndex = 0,
+            auctionState = null,
+            tradeState = null,
+        )
+    }
+
+    private fun revealCard(state: GameState): GameState {
+        check(state.phase == GamePhase.PLAYER_TURN) {
+            "Cannot reveal a card during phase ${state.phase}"
+        }
+
+        if (state.deck.isEmpty()) {
+            return state.copy(
+                phase = GamePhase.FINISHED,
+                currentFaceUpCard = null,
+                auctionState = null,
+                tradeState = null,
+            )
+        }
+
+        val (nextCard, updatedDeck) = state.deck.drawTopCard()
+
+        return state.copy(
+            deck = updatedDeck,
+            currentFaceUpCard = nextCard,
+            auctionState = null,
+            tradeState = null,
+        )
+    }
+
+    private fun chooseAuction(state: GameState): GameState {
+        check(state.phase == GamePhase.PLAYER_TURN) {
+            "Cannot start an auction during phase ${state.phase}"
+        }
+
+        val auctionCard =
+            requireNotNull(state.currentFaceUpCard) {
+                "Cannot start an auction without a revealed animal card"
+            }
+
+        return state.copy(
+            phase = GamePhase.AUCTION,
+            currentFaceUpCard = null,
+            auctionState = AuctionState(auctionCard = auctionCard),
+            tradeState = null,
+        )
+    }
+
+    private fun chooseTrade(
+        state: GameState,
+        command: GameCommand.ChooseTrade,
+    ): GameState {
+        check(state.phase == GamePhase.PLAYER_TURN) {
+            "Cannot start a trade during phase ${state.phase}"
+        }
+
+        val activePlayer = requireActivePlayer(state)
+        require(command.challengedPlayerId != activePlayer.id) {
+            "Active player cannot challenge themselves"
+        }
+
+        val challengedPlayer =
+            state.players.firstOrNull { it.id == command.challengedPlayerId }
+                ?: throw IllegalArgumentException(
+                    "Unknown challenged player ${command.challengedPlayerId}",
+                )
+
+        val requestedAnimalType = requireSharedAnimalType(activePlayer, challengedPlayer)
+
+        return state.copy(
+            phase = GamePhase.TRADE,
+            auctionState = null,
+            tradeState =
+                TradeState(
+                    initiatingPlayerId = activePlayer.id,
+                    challengedPlayerId = challengedPlayer.id,
+                    requestedAnimalType = requestedAnimalType,
+                ),
+        )
+    }
+
+    private fun finishRound(state: GameState): GameState {
+        check(
+            state.phase == GamePhase.AUCTION ||
+                state.phase == GamePhase.TRADE ||
+                state.phase == GamePhase.ROUND_END,
+        ) {
+            "Cannot finish a round during phase ${state.phase}"
+        }
+
+        if (state.players.isEmpty()) {
+            return state.copy(
+                phase = GamePhase.FINISHED,
+                currentFaceUpCard = null,
+                auctionState = null,
+                tradeState = null,
+            )
+        }
+
+        val nextPlayerIndex = (state.currentPlayerIndex + 1) % state.players.size
+        val nextPhase = if (state.deck.isEmpty()) GamePhase.FINISHED else GamePhase.PLAYER_TURN
+
+        return state.copy(
+            phase = nextPhase,
+            roundNumber = state.roundNumber + 1,
+            currentPlayerIndex = nextPlayerIndex,
+            currentFaceUpCard = null,
+            auctionState = null,
+            tradeState = null,
+        )
+    }
+
+    private fun createPrototypeDeck(): AnimalDeck =
+        AnimalDeck(
+            listOf(
+                AnimalCard(id = "1", type = AnimalType.COW),
+                AnimalCard(id = "2", type = AnimalType.DOG),
+                AnimalCard(id = "3", type = AnimalType.CAT),
+            ),
+        )
+
+    private fun requireActivePlayer(state: GameState): PlayerState =
+        state.players.getOrNull(state.currentPlayerIndex)
+            ?: throw IllegalStateException("No active player at index ${state.currentPlayerIndex}")
+
+    private fun requireSharedAnimalType(
+        activePlayer: PlayerState,
+        challengedPlayer: PlayerState,
+    ): AnimalType =
+        activePlayer.animals
+            .map { it.type }
+            .firstOrNull { animalType -> challengedPlayer.animals.any { it.type == animalType } }
+            ?: throw IllegalArgumentException(
+                "Players ${activePlayer.id} and ${challengedPlayer.id} do not share an animal type",
+            )
+}

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
@@ -67,15 +67,17 @@ class GameStateMachine {
             "Cannot start an auction during phase ${state.phase}"
         }
 
-        val auctionCard =
-            requireNotNull(state.currentFaceUpCard) {
-                "Cannot start an auction without a revealed animal card"
-            }
+        check(!state.deck.isEmpty()) {
+            "Cannot start an auction without animal cards in the deck"
+        }
+
+        val (auctionCard, updatedDeck) = state.deck.drawTopCard()
 
         return state.copy(
             phase = GamePhase.AUCTION,
+            deck = updatedDeck,
             currentFaceUpCard = null,
-            auctionState = AuctionState(auctionCard = auctionCard),
+            auctionState = AuctionState(auctionCard = requireNotNull(auctionCard)),
             tradeState = null,
         )
     }

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
@@ -119,12 +119,12 @@ class GameSessionTest {
     fun test_chooseAuction_updatesStoredState() {
         val session = GameSession("12345", "player-1")
         session.startGame()
-        session.revealNextCard()
 
         val state = session.chooseAuction()
 
         assertEquals(GamePhase.AUCTION, state.phase)
         assertNotNull(state.auctionState)
+        assertEquals(2, state.deck.size())
         assertNull(state.currentFaceUpCard)
         assertEquals(GamePhase.AUCTION, session.gameState.phase)
     }
@@ -143,7 +143,6 @@ class GameSessionTest {
     fun test_finishRound_updatesStoredState() {
         val session = GameSession("12345", "player-1")
         session.startGame()
-        session.revealNextCard()
         session.chooseAuction()
 
         val state = session.finishRound()

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
@@ -3,6 +3,7 @@ package at.aau.kuhhandel.server.model
 import at.aau.kuhhandel.shared.enums.GamePhase
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -112,5 +113,45 @@ class GameSessionTest {
         assertNull(finalState.currentFaceUpCard)
         assertNull(finalState.auctionState)
         assertNull(finalState.tradeState)
+    }
+
+    @Test
+    fun test_chooseAuction_updatesStoredState() {
+        val session = GameSession("12345", "player-1")
+        session.startGame()
+        session.revealNextCard()
+
+        val state = session.chooseAuction()
+
+        assertEquals(GamePhase.AUCTION, state.phase)
+        assertNotNull(state.auctionState)
+        assertNull(state.currentFaceUpCard)
+        assertEquals(GamePhase.AUCTION, session.gameState.phase)
+    }
+
+    @Test
+    fun test_chooseTrade_rejectsUnknownPlayer() {
+        val session = GameSession("12345", "player-1")
+        session.startGame()
+
+        assertFailsWith<IllegalArgumentException> {
+            session.chooseTrade("player-2")
+        }
+    }
+
+    @Test
+    fun test_finishRound_updatesStoredState() {
+        val session = GameSession("12345", "player-1")
+        session.startGame()
+        session.revealNextCard()
+        session.chooseAuction()
+
+        val state = session.finishRound()
+
+        assertEquals(GamePhase.PLAYER_TURN, state.phase)
+        assertEquals(2, state.roundNumber)
+        assertNull(state.auctionState)
+        assertNull(state.tradeState)
+        assertEquals(state, session.gameState)
     }
 }

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
@@ -129,13 +129,13 @@ class GameServiceTest {
         val service = GameService()
         val session = service.createGame("player-1")
         service.startGame(session.gameId)
-        service.revealNextCard(session.gameId)
 
         val state = service.chooseAuction(session.gameId)
 
         assertNotNull(state)
         assertEquals(GamePhase.AUCTION, state.phase)
         assertNotNull(state.auctionState)
+        assertEquals(2, state.deck.size())
         assertNull(state.currentFaceUpCard)
     }
 
@@ -173,7 +173,6 @@ class GameServiceTest {
         val service = GameService()
         val session = service.createGame("player-1")
         service.startGame(session.gameId)
-        service.revealNextCard(session.gameId)
         service.chooseAuction(session.gameId)
 
         val state = service.finishRound(session.gameId)

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
@@ -3,6 +3,7 @@ package at.aau.kuhhandel.server.service
 import at.aau.kuhhandel.shared.enums.GamePhase
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -121,5 +122,75 @@ class GameServiceTest {
         assertNotNull(finalState)
         assertEquals(GamePhase.FINISHED, finalState.phase)
         assertNull(finalState.currentFaceUpCard)
+    }
+
+    @Test
+    fun test_chooseAuction_updatesGameState() {
+        val service = GameService()
+        val session = service.createGame("player-1")
+        service.startGame(session.gameId)
+        service.revealNextCard(session.gameId)
+
+        val state = service.chooseAuction(session.gameId)
+
+        assertNotNull(state)
+        assertEquals(GamePhase.AUCTION, state.phase)
+        assertNotNull(state.auctionState)
+        assertNull(state.currentFaceUpCard)
+    }
+
+    @Test
+    fun test_chooseAuction_returnsNull_forInvalidGameId() {
+        val service = GameService()
+
+        val result = service.chooseAuction("99999")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun test_chooseTrade_returnsNull_forInvalidGameId() {
+        val service = GameService()
+
+        val result = service.chooseTrade("99999", "player-2")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun test_chooseTrade_propagatesInvalidTrade() {
+        val service = GameService()
+        val session = service.createGame("player-1")
+        service.startGame(session.gameId)
+
+        assertFailsWith<IllegalArgumentException> {
+            service.chooseTrade(session.gameId, "player-2")
+        }
+    }
+
+    @Test
+    fun test_finishRound_updatesGameState() {
+        val service = GameService()
+        val session = service.createGame("player-1")
+        service.startGame(session.gameId)
+        service.revealNextCard(session.gameId)
+        service.chooseAuction(session.gameId)
+
+        val state = service.finishRound(session.gameId)
+
+        assertNotNull(state)
+        assertEquals(GamePhase.PLAYER_TURN, state.phase)
+        assertEquals(2, state.roundNumber)
+        assertNull(state.auctionState)
+        assertNull(state.tradeState)
+    }
+
+    @Test
+    fun test_finishRound_returnsNull_forInvalidGameId() {
+        val service = GameService()
+
+        val result = service.finishRound("99999")
+
+        assertNull(result)
     }
 }

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
@@ -90,33 +90,42 @@ class GameStateMachineTest {
     }
 
     @Test
-    fun test_chooseAuction_movesPhaseToAuction() {
-        val card = AnimalCard(id = "1", type = AnimalType.COW)
+    fun test_chooseAuction_drawsTopCardAndMovesPhaseToAuction() {
         val state =
             GameState(
                 phase = GamePhase.PLAYER_TURN,
                 roundNumber = 1,
                 players = listOf(player("player-1")),
-                currentFaceUpCard = card,
+                deck =
+                    AnimalDeck(
+                        listOf(
+                            AnimalCard(id = "1", type = AnimalType.COW),
+                            AnimalCard(id = "2", type = AnimalType.DOG),
+                        ),
+                    ),
             )
 
         val updatedState = stateMachine.apply(state, GameCommand.ChooseAuction)
 
         assertEquals(GamePhase.AUCTION, updatedState.phase)
-        assertEquals(AuctionState(auctionCard = card), updatedState.auctionState)
+        assertEquals(
+            AuctionState(auctionCard = AnimalCard(id = "2", type = AnimalType.DOG)),
+            updatedState.auctionState,
+        )
+        assertEquals(1, updatedState.deck.size())
         assertNull(updatedState.currentFaceUpCard)
         assertNull(updatedState.tradeState)
     }
 
     @Test
-    fun test_chooseAuction_rejectsMissingFaceUpCard() {
+    fun test_chooseAuction_rejectsEmptyDeck() {
         val state =
             GameState(
                 phase = GamePhase.PLAYER_TURN,
                 players = listOf(player("player-1")),
             )
 
-        assertFailsWith<IllegalArgumentException> {
+        assertFailsWith<IllegalStateException> {
             stateMachine.apply(state, GameCommand.ChooseAuction)
         }
     }
@@ -126,7 +135,7 @@ class GameStateMachineTest {
         val state =
             GameState(
                 phase = GamePhase.TRADE,
-                currentFaceUpCard = AnimalCard(id = "1", type = AnimalType.COW),
+                deck = AnimalDeck(listOf(AnimalCard(id = "1", type = AnimalType.COW))),
             )
 
         assertFailsWith<IllegalStateException> {

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
@@ -1,0 +1,333 @@
+package at.aau.kuhhandel.server.service
+
+import at.aau.kuhhandel.shared.enums.AnimalType
+import at.aau.kuhhandel.shared.enums.GamePhase
+import at.aau.kuhhandel.shared.model.AnimalCard
+import at.aau.kuhhandel.shared.model.AnimalDeck
+import at.aau.kuhhandel.shared.model.AuctionState
+import at.aau.kuhhandel.shared.model.GameState
+import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.TradeState
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class GameStateMachineTest {
+    private val stateMachine = GameStateMachine()
+
+    @Test
+    fun test_startGame_initializesPlayerTurnAndRoundOne() {
+        val state = GameState(players = listOf(player("player-1")))
+
+        val updatedState = stateMachine.apply(state, GameCommand.StartGame)
+
+        assertEquals(GamePhase.PLAYER_TURN, updatedState.phase)
+        assertEquals(1, updatedState.roundNumber)
+        assertEquals(3, updatedState.deck.size())
+        assertEquals(0, updatedState.currentPlayerIndex)
+        assertNull(updatedState.currentFaceUpCard)
+        assertNull(updatedState.auctionState)
+        assertNull(updatedState.tradeState)
+    }
+
+    @Test
+    fun test_startGame_rejectsAlreadyStartedGame() {
+        val state = GameState(phase = GamePhase.PLAYER_TURN)
+
+        assertFailsWith<IllegalStateException> {
+            stateMachine.apply(state, GameCommand.StartGame)
+        }
+    }
+
+    @Test
+    fun test_revealCard_drawsTopCardDuringPlayerTurn() {
+        val state =
+            GameState(
+                phase = GamePhase.PLAYER_TURN,
+                roundNumber = 1,
+                players = listOf(player("player-1")),
+                deck =
+                    AnimalDeck(
+                        listOf(
+                            AnimalCard(id = "1", type = AnimalType.COW),
+                            AnimalCard(id = "2", type = AnimalType.DOG),
+                        ),
+                    ),
+            )
+
+        val updatedState = stateMachine.apply(state, GameCommand.RevealCard)
+
+        assertEquals(GamePhase.PLAYER_TURN, updatedState.phase)
+        assertEquals(1, updatedState.deck.size())
+        assertEquals(AnimalType.DOG, updatedState.currentFaceUpCard?.type)
+        assertNull(updatedState.auctionState)
+        assertNull(updatedState.tradeState)
+    }
+
+    @Test
+    fun test_revealCard_finishesGameWhenDeckIsAlreadyEmpty() {
+        val state =
+            GameState(
+                phase = GamePhase.PLAYER_TURN,
+                roundNumber = 1,
+                players = listOf(player("player-1")),
+            )
+
+        val updatedState = stateMachine.apply(state, GameCommand.RevealCard)
+
+        assertEquals(GamePhase.FINISHED, updatedState.phase)
+        assertNull(updatedState.currentFaceUpCard)
+    }
+
+    @Test
+    fun test_revealCard_rejectsWrongPhase() {
+        val state = GameState(phase = GamePhase.AUCTION)
+
+        assertFailsWith<IllegalStateException> {
+            stateMachine.apply(state, GameCommand.RevealCard)
+        }
+    }
+
+    @Test
+    fun test_chooseAuction_movesPhaseToAuction() {
+        val card = AnimalCard(id = "1", type = AnimalType.COW)
+        val state =
+            GameState(
+                phase = GamePhase.PLAYER_TURN,
+                roundNumber = 1,
+                players = listOf(player("player-1")),
+                currentFaceUpCard = card,
+            )
+
+        val updatedState = stateMachine.apply(state, GameCommand.ChooseAuction)
+
+        assertEquals(GamePhase.AUCTION, updatedState.phase)
+        assertEquals(AuctionState(auctionCard = card), updatedState.auctionState)
+        assertNull(updatedState.currentFaceUpCard)
+        assertNull(updatedState.tradeState)
+    }
+
+    @Test
+    fun test_chooseAuction_rejectsMissingFaceUpCard() {
+        val state =
+            GameState(
+                phase = GamePhase.PLAYER_TURN,
+                players = listOf(player("player-1")),
+            )
+
+        assertFailsWith<IllegalArgumentException> {
+            stateMachine.apply(state, GameCommand.ChooseAuction)
+        }
+    }
+
+    @Test
+    fun test_chooseAuction_rejectsWrongPhase() {
+        val state =
+            GameState(
+                phase = GamePhase.TRADE,
+                currentFaceUpCard = AnimalCard(id = "1", type = AnimalType.COW),
+            )
+
+        assertFailsWith<IllegalStateException> {
+            stateMachine.apply(state, GameCommand.ChooseAuction)
+        }
+    }
+
+    @Test
+    fun test_chooseTrade_movesPhaseToTrade() {
+        val cow = AnimalCard(id = "cow-1", type = AnimalType.COW)
+        val state =
+            GameState(
+                phase = GamePhase.PLAYER_TURN,
+                roundNumber = 1,
+                players =
+                    listOf(
+                        player(id = "player-1", animals = listOf(cow)),
+                        player(
+                            id = "player-2",
+                            animals = listOf(AnimalCard(id = "cow-2", type = AnimalType.COW)),
+                        ),
+                    ),
+            )
+
+        val updatedState =
+            stateMachine.apply(
+                state,
+                GameCommand.ChooseTrade(challengedPlayerId = "player-2"),
+            )
+
+        assertEquals(GamePhase.TRADE, updatedState.phase)
+        assertEquals(
+            TradeState(
+                initiatingPlayerId = "player-1",
+                challengedPlayerId = "player-2",
+                requestedAnimalType = AnimalType.COW,
+            ),
+            updatedState.tradeState,
+        )
+        assertNull(updatedState.auctionState)
+    }
+
+    @Test
+    fun test_chooseTrade_rejectsSelfChallenge() {
+        val state =
+            GameState(
+                phase = GamePhase.PLAYER_TURN,
+                players = listOf(player("player-1")),
+            )
+
+        assertFailsWith<IllegalArgumentException> {
+            stateMachine.apply(
+                state,
+                GameCommand.ChooseTrade(challengedPlayerId = "player-1"),
+            )
+        }
+    }
+
+    @Test
+    fun test_chooseTrade_rejectsWrongPhase() {
+        val state = GameState(phase = GamePhase.AUCTION)
+
+        assertFailsWith<IllegalStateException> {
+            stateMachine.apply(
+                state,
+                GameCommand.ChooseTrade(challengedPlayerId = "player-2"),
+            )
+        }
+    }
+
+    @Test
+    fun test_chooseTrade_rejectsMissingActivePlayer() {
+        val state =
+            GameState(
+                phase = GamePhase.PLAYER_TURN,
+                currentPlayerIndex = 1,
+                players = listOf(player("player-1")),
+            )
+
+        assertFailsWith<IllegalStateException> {
+            stateMachine.apply(
+                state,
+                GameCommand.ChooseTrade(challengedPlayerId = "player-2"),
+            )
+        }
+    }
+
+    @Test
+    fun test_chooseTrade_rejectsUnknownChallengedPlayer() {
+        val state =
+            GameState(
+                phase = GamePhase.PLAYER_TURN,
+                players = listOf(player("player-1")),
+            )
+
+        assertFailsWith<IllegalArgumentException> {
+            stateMachine.apply(
+                state,
+                GameCommand.ChooseTrade(challengedPlayerId = "player-2"),
+            )
+        }
+    }
+
+    @Test
+    fun test_chooseTrade_rejectsPlayersWithoutSharedAnimalType() {
+        val state =
+            GameState(
+                phase = GamePhase.PLAYER_TURN,
+                players =
+                    listOf(
+                        player(
+                            id = "player-1",
+                            animals = listOf(AnimalCard(id = "cow-1", type = AnimalType.COW)),
+                        ),
+                        player(
+                            id = "player-2",
+                            animals = listOf(AnimalCard(id = "dog-1", type = AnimalType.DOG)),
+                        ),
+                    ),
+            )
+
+        assertFailsWith<IllegalArgumentException> {
+            stateMachine.apply(
+                state,
+                GameCommand.ChooseTrade(challengedPlayerId = "player-2"),
+            )
+        }
+    }
+
+    @Test
+    fun test_finishRound_advancesToNextPlayerAndClearsRoundState() {
+        val state =
+            GameState(
+                phase = GamePhase.ROUND_END,
+                roundNumber = 1,
+                players = listOf(player("player-1"), player("player-2")),
+                currentPlayerIndex = 0,
+                deck = AnimalDeck(listOf(AnimalCard(id = "1", type = AnimalType.COW))),
+                currentFaceUpCard = AnimalCard(id = "2", type = AnimalType.DOG),
+                auctionState = AuctionState(AnimalCard(id = "3", type = AnimalType.CAT)),
+            )
+
+        val updatedState = stateMachine.apply(state, GameCommand.FinishRound)
+
+        assertEquals(GamePhase.PLAYER_TURN, updatedState.phase)
+        assertEquals(2, updatedState.roundNumber)
+        assertEquals(1, updatedState.currentPlayerIndex)
+        assertNull(updatedState.currentFaceUpCard)
+        assertNull(updatedState.auctionState)
+        assertNull(updatedState.tradeState)
+    }
+
+    @Test
+    fun test_finishRound_finishesGameWhenDeckIsEmpty() {
+        val state =
+            GameState(
+                phase = GamePhase.ROUND_END,
+                roundNumber = 1,
+                players = listOf(player("player-1")),
+            )
+
+        val updatedState = stateMachine.apply(state, GameCommand.FinishRound)
+
+        assertEquals(GamePhase.FINISHED, updatedState.phase)
+        assertEquals(2, updatedState.roundNumber)
+    }
+
+    @Test
+    fun test_finishRound_finishesGameWhenPlayersAreMissing() {
+        val state =
+            GameState(
+                phase = GamePhase.ROUND_END,
+                roundNumber = 1,
+                currentFaceUpCard = AnimalCard(id = "1", type = AnimalType.COW),
+                auctionState = AuctionState(AnimalCard(id = "2", type = AnimalType.DOG)),
+            )
+
+        val updatedState = stateMachine.apply(state, GameCommand.FinishRound)
+
+        assertEquals(GamePhase.FINISHED, updatedState.phase)
+        assertNull(updatedState.currentFaceUpCard)
+        assertNull(updatedState.auctionState)
+        assertNull(updatedState.tradeState)
+    }
+
+    @Test
+    fun test_finishRound_rejectsPlayerTurn() {
+        val state = GameState(phase = GamePhase.PLAYER_TURN)
+
+        assertFailsWith<IllegalStateException> {
+            stateMachine.apply(state, GameCommand.FinishRound)
+        }
+    }
+
+    private fun player(
+        id: String,
+        animals: List<AnimalCard> = emptyList(),
+    ): PlayerState =
+        PlayerState(
+            id = id,
+            name = id,
+            animals = animals,
+        )
+}

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class GameState(
     val phase: GamePhase = GamePhase.NOT_STARTED,
+    val roundNumber: Int = 0,
     val deck: AnimalDeck = AnimalDeck(),
     val currentFaceUpCard: AnimalCard? = null,
     val currentPlayerIndex: Int = 0,

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/GameStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/GameStateTest.kt
@@ -12,6 +12,7 @@ class GameStateTest {
         val state = GameState()
 
         assertEquals(GamePhase.NOT_STARTED, state.phase)
+        assertEquals(0, state.roundNumber)
         assertEquals(0, state.currentPlayerIndex)
         assertNull(state.currentFaceUpCard)
         assertTrue(state.players.isEmpty())
@@ -34,6 +35,7 @@ class GameStateTest {
         val state =
             GameState(
                 phase = GamePhase.AUCTION,
+                roundNumber = 2,
                 deck = AnimalDeck(listOf(card)),
                 currentFaceUpCard = card,
                 currentPlayerIndex = 1,
@@ -43,6 +45,7 @@ class GameStateTest {
             )
 
         assertEquals(GamePhase.AUCTION, state.phase)
+        assertEquals(2, state.roundNumber)
         assertEquals(card, state.currentFaceUpCard)
         assertEquals(1, state.currentPlayerIndex)
         assertEquals(auctionState, state.auctionState)


### PR DESCRIPTION
**Summary**

- Added a server-side round flow state machine for deterministic game phase transitions.
- Added `GameCommand` to represent supported round-flow actions.
- Added `roundNumber` to `GameState` so round progression is explicit in the shared synchronized state.
- Refactored `GameSession` so start, reveal, auction, trade, and round-end actions delegate to the state machine.
- Extended `GameService` with methods for choosing an auction, choosing a trade, and finishing a round.
- Updated auction start behavior so choosing an auction draws the top animal card and enters the `AUCTION` phase.
- Updated `GameStateTest`, `GameStateMachineTest`, `GameSessionTest`, and `GameServiceTest` to cover the new behavior.


**Notes**

- The current deck setup still uses the prototype deck.
- Full setup with all animal cards, initial money distribution, Goldesel payouts, and scoring is left for follow-up work.

**Closes #126**
