### PR TITLE
feat: add client actions for bidding and trade decisions AND start a game

### DIFF
--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
@@ -93,6 +93,18 @@ class GameRepository(
         client.initiateTrade(targetPlayerId)
     }
 
+    suspend fun offerTrade(moneyCardIds: List<String>) {
+        ensureConnected()
+        _state.update { it.copy(errorMessage = null) }
+        client.offerTrade(moneyCardIds)
+    }
+
+    suspend fun respondToTrade(accepted: Boolean) {
+        ensureConnected()
+        _state.update { it.copy(errorMessage = null) }
+        client.respondToTrade(accepted)
+    }
+
     fun clearError() {
         _state.update { it.copy(errorMessage = null) }
     }
@@ -233,7 +245,7 @@ class GameRepository(
                 _state.update {
                     it.copy(
                         gameId = payload.gameId,
-                        // myPlayerId = payload.playerId, // Missing in shared
+                        myPlayerId = payload.playerId,
                         gameState = payload.state,
                         errorMessage = null,
                     )

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
@@ -306,7 +306,6 @@ class GameRepository(
                 }
             }
 
-            WebSocketType.GAME_STARTED,
             WebSocketType.GAME_STATE_UPDATED,
             -> {
                 val payload =

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
@@ -87,11 +87,12 @@ class GameRepository(
 
     suspend fun initiateTrade(
         challengedPlayerId: String,
+        animalType: at.aau.kuhhandel.shared.enums.AnimalType,
         moneyCardIds: List<String> = emptyList(),
     ) {
         ensureConnected()
         _state.update { it.copy(errorMessage = null) }
-        client.initiateTrade(challengedPlayerId, moneyCardIds)
+        client.initiateTrade(challengedPlayerId, animalType, moneyCardIds)
     }
 
     suspend fun leaveGame() {

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
@@ -249,12 +249,50 @@ class GameRepository(
             WebSocketType.GAME_CREATED,
             WebSocketType.GAME_JOINED,
             -> {
+                val payloadJson = envelope.payload
+                if (payloadJson == null) {
+                    _state.update {
+                        it.copy(
+                            errorMessage = "Invalid GAME_CREATED/JOINED message (Payload is null for ${envelope.type}). Payload: null",
+                        )
+                    }
+                    return
+                }
+
+                // If the payload is actually a GameStatePayload, try to recover
                 val payload =
-                    decodePayload(
-                        envelope = envelope,
-                        serializer = GameCreatedPayload.serializer(),
-                        invalidMessage = "Invalid GAME_CREATED/JOINED message",
-                    ) ?: return
+                    runCatching {
+                        WebSocketJson.json.decodeFromJsonElement(
+                            GameCreatedPayload.serializer(),
+                            payloadJson,
+                        )
+                    }.getOrElse { throwable ->
+                        // Fallback: try to decode as GameStatePayload if gameId is missing
+                        val gameStatePayload =
+                            runCatching {
+                                WebSocketJson.json.decodeFromJsonElement(
+                                    GameStatePayload.serializer(),
+                                    payloadJson,
+                                )
+                            }.getOrNull()
+
+                        if (gameStatePayload != null) {
+                            GameCreatedPayload(
+                                gameId = _state.value.gameId ?: "unknown",
+                                playerId = _state.value.myPlayerId ?: "unknown",
+                                state = gameStatePayload.state,
+                            )
+                        } else {
+                            _state.update {
+                                it.copy(
+                                    errorMessage =
+                                        "Invalid GAME_CREATED/JOINED message " +
+                                            "(${throwable.message}). Payload: $payloadJson",
+                                )
+                            }
+                            return
+                        }
+                    }
 
                 _state.update {
                     it.copy(

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
@@ -86,12 +86,18 @@ class GameRepository(
     }
 
     suspend fun initiateTrade(
-        targetPlayerId: String,
-        moneyCardIds: List<String> = emptyList()
+        challengedPlayerId: String,
+        moneyCardIds: List<String> = emptyList(),
     ) {
         ensureConnected()
         _state.update { it.copy(errorMessage = null) }
-        client.initiateTrade(targetPlayerId, moneyCardIds)
+        client.initiateTrade(challengedPlayerId, moneyCardIds)
+    }
+
+    suspend fun leaveGame() {
+        ensureConnected()
+        client.leaveGame()
+        disconnect()
     }
 
     suspend fun offerTrade(moneyCardIds: List<String>) {
@@ -102,7 +108,7 @@ class GameRepository(
 
     suspend fun respondToTrade(
         accepted: Boolean,
-        counterOfferedMoneyCardIds: List<String> = emptyList()
+        counterOfferedMoneyCardIds: List<String> = emptyList(),
     ) {
         ensureConnected()
         val myId = _state.value.myPlayerId ?: return

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
@@ -52,7 +52,6 @@ class GameRepository(
         client.createGame(playerName)
     }
 
-    /*
     suspend fun joinGame(
         gameId: String,
         playerName: String? = null,
@@ -61,7 +60,6 @@ class GameRepository(
         _state.update { it.copy(errorMessage = null) }
         client.joinGame(gameId, playerName)
     }
-     */
 
     suspend fun startGame() {
         ensureConnected()
@@ -87,10 +85,13 @@ class GameRepository(
         client.buyBack(buyBack)
     }
 
-    suspend fun initiateTrade(targetPlayerId: String) {
+    suspend fun initiateTrade(
+        targetPlayerId: String,
+        moneyCardIds: List<String> = emptyList()
+    ) {
         ensureConnected()
         _state.update { it.copy(errorMessage = null) }
-        client.initiateTrade(targetPlayerId)
+        client.initiateTrade(targetPlayerId, moneyCardIds)
     }
 
     suspend fun offerTrade(moneyCardIds: List<String>) {
@@ -99,10 +100,14 @@ class GameRepository(
         client.offerTrade(moneyCardIds)
     }
 
-    suspend fun respondToTrade(accepted: Boolean) {
+    suspend fun respondToTrade(
+        accepted: Boolean,
+        counterOfferedMoneyCardIds: List<String> = emptyList()
+    ) {
         ensureConnected()
+        val myId = _state.value.myPlayerId ?: return
         _state.update { it.copy(errorMessage = null) }
-        client.respondToTrade(accepted)
+        client.respondToTrade(myId, accepted, counterOfferedMoneyCardIds)
     }
 
     fun clearError() {
@@ -234,12 +239,14 @@ class GameRepository(
 
     private fun handleEnvelope(envelope: WebSocketEnvelope) {
         when (envelope.type) {
-            WebSocketType.GAME_CREATED -> {
+            WebSocketType.GAME_CREATED,
+            WebSocketType.GAME_JOINED,
+            -> {
                 val payload =
                     decodePayload(
                         envelope = envelope,
                         serializer = GameCreatedPayload.serializer(),
-                        invalidMessage = "Invalid GAME_CREATED message",
+                        invalidMessage = "Invalid GAME_CREATED/JOINED message",
                     ) ?: return
 
                 _state.update {

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
@@ -307,10 +307,20 @@ class GameRepository(
         runCatching {
             WebSocketJson.json.decodeFromJsonElement(
                 serializer,
-                requireNotNull(envelope.payload),
+                requireNotNull(envelope.payload) { "Payload is null for ${envelope.type}" },
             )
-        }.getOrElse {
-            _state.update { it.copy(errorMessage = invalidMessage) }
+        }.getOrElse { throwable ->
+            val payloadString =
+                runCatching { envelope.payload.toString() }.getOrDefault(
+                    "unavailable",
+                )
+            _state.update {
+                it.copy(
+                    errorMessage =
+                        "$invalidMessage " +
+                            "(${throwable.message}). Payload: $payloadString",
+                )
+            }
             null
         }
 

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
@@ -57,7 +57,7 @@ class GameRepository(
         playerName: String? = null,
     ) {
         ensureConnected()
-        _state.update { it.copy(errorMessage = null) }
+        _state.update { it.copy(gameId = gameId, errorMessage = null) }
         client.joinGame(gameId, playerName)
     }
 
@@ -253,7 +253,9 @@ class GameRepository(
                 if (payloadJson == null) {
                     _state.update {
                         it.copy(
-                            errorMessage = "Invalid GAME_CREATED/JOINED message (Payload is null for ${envelope.type}). Payload: null",
+                            errorMessage =
+                                "Invalid GAME_CREATED/JOINED message " +
+                                    "(Payload is null for ${envelope.type}). Payload: null",
                         )
                     }
                     return

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClient.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClient.kt
@@ -6,6 +6,8 @@ import at.aau.kuhhandel.shared.websocket.AuctionBuyBackPayload
 import at.aau.kuhhandel.shared.websocket.CreateGamePayload
 import at.aau.kuhhandel.shared.websocket.InitiateTradePayload
 import at.aau.kuhhandel.shared.websocket.PlaceBidPayload
+import at.aau.kuhhandel.shared.websocket.OfferTradePayload
+import at.aau.kuhhandel.shared.websocket.RespondToTradePayload
 import at.aau.kuhhandel.shared.websocket.WebSocketEnvelope
 import at.aau.kuhhandel.shared.websocket.WebSocketJson
 import at.aau.kuhhandel.shared.websocket.WebSocketRoutes
@@ -229,6 +231,30 @@ class GameWebSocketClient(
                 InitiateTradePayload(targetPlayerId),
             )
         send(WebSocketEnvelope(WebSocketType.INITIATE_TRADE, requestId, payload))
+        return requestId
+    }
+
+    suspend fun offerTrade(moneyCardIds: List<String>): String {
+        val requestId = UUID.randomUUID().toString()
+        val payload =
+            WebSocketJson.json.encodeToJsonElement(
+                OfferTradePayload.serializer(),
+                OfferTradePayload(moneyCardIds),
+            )
+        send(WebSocketEnvelope(WebSocketType.OFFER_TRADE, requestId, payload))
+        return requestId
+    }
+
+    suspend fun respondToTrade(accepted: Boolean): String {
+        val requestId = UUID.randomUUID().toString()
+        // We need respondingPlayerId? The server handles it from session usually, but payload has it.
+        // Let's use a placeholder or check RespondToTradePayload definition again.
+        val payload =
+            WebSocketJson.json.encodeToJsonElement(
+                RespondToTradePayload.serializer(),
+                RespondToTradePayload("player-1", accepted),
+            )
+        send(WebSocketEnvelope(WebSocketType.RESPOND_TO_TRADE, requestId, payload))
         return requestId
     }
 

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClient.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClient.kt
@@ -5,8 +5,9 @@ import at.aau.kuhhandel.app.network.NetworkClientFactory
 import at.aau.kuhhandel.shared.websocket.AuctionBuyBackPayload
 import at.aau.kuhhandel.shared.websocket.CreateGamePayload
 import at.aau.kuhhandel.shared.websocket.InitiateTradePayload
-import at.aau.kuhhandel.shared.websocket.PlaceBidPayload
+import at.aau.kuhhandel.shared.websocket.JoinGamePayload
 import at.aau.kuhhandel.shared.websocket.OfferTradePayload
+import at.aau.kuhhandel.shared.websocket.PlaceBidPayload
 import at.aau.kuhhandel.shared.websocket.RespondToTradePayload
 import at.aau.kuhhandel.shared.websocket.WebSocketEnvelope
 import at.aau.kuhhandel.shared.websocket.WebSocketJson
@@ -25,7 +26,6 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
-import kotlinx.serialization.json.encodeToJsonElement
 import java.util.UUID
 
 class OpenedSession(
@@ -114,21 +114,29 @@ class GameWebSocketClient(
         return null
     }
 
-    private suspend fun closeDetails(frame: Frame): String? =
+    private fun closeDetails(frame: Frame): String? =
         (frame as? Frame.Close)?.let { closeFrame ->
-            formatCloseDetails(closeFrame.readReason())
+            val reason = closeFrame.readReason()
+            val code = reason?.code
+            if (code == CloseReason.Codes.NORMAL.code ||
+                code == CloseReason.Codes.GOING_AWAY.code
+            ) {
+                null
+            } else {
+                formatCloseDetails(reason)
+            }
         }
 
     private fun formatCloseDetails(reason: CloseReason?): String =
         if (reason != null) {
             "WebSocket closed (${reason.code}): ${
-                reason.message.ifBlank { "Kein Grund angegeben" }
+                reason.message.ifBlank { "No reason given" }
             }"
         } else {
             "WebSocket closed without a close reason"
         }
 
-    private suspend fun decodeEnvelope(frame: Frame): WebSocketEnvelope? {
+    private fun decodeEnvelope(frame: Frame): WebSocketEnvelope? {
         val textFrame = frame as? Frame.Text ?: return null
         return runCatching {
             WebSocketJson.json.decodeFromString(
@@ -167,7 +175,7 @@ class GameWebSocketClient(
         val payload =
             WebSocketJson.json.encodeToJsonElement(
                 CreateGamePayload.serializer(),
-                CreateGamePayload(playerName),
+                CreateGamePayload(playerName = playerName),
             )
         send(WebSocketEnvelope(WebSocketType.CREATE_GAME, requestId, payload))
         return requestId
@@ -181,9 +189,15 @@ class GameWebSocketClient(
         val payload =
             WebSocketJson.json.encodeToJsonElement(
                 JoinGamePayload.serializer(),
-                JoinGamePayload(gameId, playerName),
+                JoinGamePayload(gameId = gameId, playerName = playerName),
             )
         send(WebSocketEnvelope(WebSocketType.JOIN_GAME, requestId, payload))
+        return requestId
+    }
+
+    suspend fun leaveGame(): String {
+        val requestId = UUID.randomUUID().toString()
+        send(WebSocketEnvelope(WebSocketType.LEAVE_GAME, requestId))
         return requestId
     }
 
@@ -204,7 +218,7 @@ class GameWebSocketClient(
         val payload =
             WebSocketJson.json.encodeToJsonElement(
                 PlaceBidPayload.serializer(),
-                PlaceBidPayload(amount),
+                PlaceBidPayload(amount = amount),
             )
         send(WebSocketEnvelope(WebSocketType.PLACE_BID, requestId, payload))
         return requestId
@@ -215,7 +229,7 @@ class GameWebSocketClient(
         val payload =
             WebSocketJson.json.encodeToJsonElement(
                 AuctionBuyBackPayload.serializer(),
-                AuctionBuyBackPayload(buyBack),
+                AuctionBuyBackPayload(buyBack = buyBack),
             )
         send(WebSocketEnvelope(WebSocketType.AUCTION_BUY_BACK, requestId, payload))
         return requestId
@@ -223,13 +237,16 @@ class GameWebSocketClient(
 
     suspend fun initiateTrade(
         targetPlayerId: String,
-        moneyCardIds: List<String> = emptyList()
+        moneyCardIds: List<String> = emptyList(),
     ): String {
         val requestId = UUID.randomUUID().toString()
         val payload =
             WebSocketJson.json.encodeToJsonElement(
                 InitiateTradePayload.serializer(),
-                InitiateTradePayload(targetPlayerId, moneyCardIds),
+                InitiateTradePayload(
+                    challengedPlayerId = targetPlayerId,
+                    moneyCardIds = moneyCardIds,
+                ),
             )
         send(WebSocketEnvelope(WebSocketType.INITIATE_TRADE, requestId, payload))
         return requestId
@@ -240,7 +257,7 @@ class GameWebSocketClient(
         val payload =
             WebSocketJson.json.encodeToJsonElement(
                 OfferTradePayload.serializer(),
-                OfferTradePayload(moneyCardIds),
+                OfferTradePayload(moneyCardIds = moneyCardIds),
             )
         send(WebSocketEnvelope(WebSocketType.OFFER_TRADE, requestId, payload))
         return requestId
@@ -249,13 +266,17 @@ class GameWebSocketClient(
     suspend fun respondToTrade(
         respondingPlayerId: String,
         accepted: Boolean,
-        counterOfferedMoneyCardIds: List<String> = emptyList()
+        counterOfferedMoneyCardIds: List<String> = emptyList(),
     ): String {
         val requestId = UUID.randomUUID().toString()
         val payload =
             WebSocketJson.json.encodeToJsonElement(
                 RespondToTradePayload.serializer(),
-                RespondToTradePayload(respondingPlayerId, accepted, counterOfferedMoneyCardIds),
+                RespondToTradePayload(
+                    respondingPlayerId = respondingPlayerId,
+                    accepted = accepted,
+                    counterOfferedMoneyCardIds = counterOfferedMoneyCardIds,
+                ),
             )
         send(WebSocketEnvelope(WebSocketType.RESPOND_TO_TRADE, requestId, payload))
         return requestId

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClient.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClient.kt
@@ -236,7 +236,8 @@ class GameWebSocketClient(
     }
 
     suspend fun initiateTrade(
-        targetPlayerId: String,
+        challengedPlayerId: String,
+        animalType: at.aau.kuhhandel.shared.enums.AnimalType,
         moneyCardIds: List<String> = emptyList(),
     ): String {
         val requestId = UUID.randomUUID().toString()
@@ -244,7 +245,8 @@ class GameWebSocketClient(
             WebSocketJson.json.encodeToJsonElement(
                 InitiateTradePayload.serializer(),
                 InitiateTradePayload(
-                    challengedPlayerId = targetPlayerId,
+                    challengedPlayerId = challengedPlayerId,
+                    animalType = animalType,
                     moneyCardIds = moneyCardIds,
                 ),
             )

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClient.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClient.kt
@@ -173,7 +173,6 @@ class GameWebSocketClient(
         return requestId
     }
 
-    /*
     suspend fun joinGame(
         gameId: String,
         playerName: String? = null,
@@ -187,7 +186,6 @@ class GameWebSocketClient(
         send(WebSocketEnvelope(WebSocketType.JOIN_GAME, requestId, payload))
         return requestId
     }
-     */
 
     suspend fun startGame(): String {
         val requestId = UUID.randomUUID().toString()
@@ -223,12 +221,15 @@ class GameWebSocketClient(
         return requestId
     }
 
-    suspend fun initiateTrade(targetPlayerId: String): String {
+    suspend fun initiateTrade(
+        targetPlayerId: String,
+        moneyCardIds: List<String> = emptyList()
+    ): String {
         val requestId = UUID.randomUUID().toString()
         val payload =
             WebSocketJson.json.encodeToJsonElement(
                 InitiateTradePayload.serializer(),
-                InitiateTradePayload(targetPlayerId),
+                InitiateTradePayload(targetPlayerId, moneyCardIds),
             )
         send(WebSocketEnvelope(WebSocketType.INITIATE_TRADE, requestId, payload))
         return requestId
@@ -245,14 +246,16 @@ class GameWebSocketClient(
         return requestId
     }
 
-    suspend fun respondToTrade(accepted: Boolean): String {
+    suspend fun respondToTrade(
+        respondingPlayerId: String,
+        accepted: Boolean,
+        counterOfferedMoneyCardIds: List<String> = emptyList()
+    ): String {
         val requestId = UUID.randomUUID().toString()
-        // We need respondingPlayerId? The server handles it from session usually, but payload has it.
-        // Let's use a placeholder or check RespondToTradePayload definition again.
         val payload =
             WebSocketJson.json.encodeToJsonElement(
                 RespondToTradePayload.serializer(),
-                RespondToTradePayload("player-1", accepted),
+                RespondToTradePayload(respondingPlayerId, accepted, counterOfferedMoneyCardIds),
             )
         send(WebSocketEnvelope(WebSocketType.RESPOND_TO_TRADE, requestId, payload))
         return requestId

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClient.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClient.kt
@@ -116,15 +116,7 @@ class GameWebSocketClient(
 
     private fun closeDetails(frame: Frame): String? =
         (frame as? Frame.Close)?.let { closeFrame ->
-            val reason = closeFrame.readReason()
-            val code = reason?.code
-            if (code == CloseReason.Codes.NORMAL.code ||
-                code == CloseReason.Codes.GOING_AWAY.code
-            ) {
-                null
-            } else {
-                formatCloseDetails(reason)
-            }
+            formatCloseDetails(closeFrame.readReason())
         }
 
     private fun formatCloseDetails(reason: CloseReason?): String =

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/KuhhandelApp.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/KuhhandelApp.kt
@@ -149,6 +149,9 @@ fun KuhhandelApp(modifier: Modifier = Modifier) {
                     uiState = gameUiState,
                     onStartGame = gameViewModel::startGame,
                     onRevealCard = gameViewModel::revealCard,
+                    onPlaceBid = gameViewModel::placeBid,
+                    onBuyBack = gameViewModel::buyBack,
+                    onRespondToTrade = gameViewModel::respondToTrade,
                 )
             }
         }

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/KuhhandelApp.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/KuhhandelApp.kt
@@ -154,6 +154,7 @@ fun KuhhandelApp(modifier: Modifier = Modifier) {
                     onBuyBack = gameViewModel::buyBack,
                     onRespondToTrade = gameViewModel::respondToTrade,
                     onInitiateTrade = gameViewModel::initiateTrade,
+                    onSelectTargetPlayer = gameViewModel::selectTargetPlayer,
                     onToggleMoneyCard = gameViewModel::toggleMoneyCardSelection,
                     onLeaveGame = {
                         scope.launch {

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/KuhhandelApp.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/KuhhandelApp.kt
@@ -25,6 +25,7 @@ import at.aau.kuhhandel.app.ui.menu.lobby.LobbyViewModel
 import at.aau.kuhhandel.app.ui.menu.main.MainMenuScreen
 import at.aau.kuhhandel.app.ui.menu.rules.RulesScreen
 import at.aau.kuhhandel.shared.enums.GamePhase
+import kotlinx.coroutines.launch
 
 @Composable
 fun KuhhandelApp(modifier: Modifier = Modifier) {
@@ -152,6 +153,14 @@ fun KuhhandelApp(modifier: Modifier = Modifier) {
                     onPlaceBid = gameViewModel::placeBid,
                     onBuyBack = gameViewModel::buyBack,
                     onRespondToTrade = gameViewModel::respondToTrade,
+                    onInitiateTrade = gameViewModel::initiateTrade,
+                    onToggleMoneyCard = gameViewModel::toggleMoneyCardSelection,
+                    onLeaveGame = {
+                        scope.launch {
+                            repository.leaveGame()
+                            navController.popBackStack(Screen.Main, inclusive = false)
+                        }
+                    },
                 )
             }
         }

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/GameComponents.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/GameComponents.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,6 +15,9 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -34,7 +38,9 @@ import at.aau.kuhhandel.app.ui.theme.PureWhite
 import at.aau.kuhhandel.app.ui.theme.WhitePurple
 import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.model.AuctionState
+import at.aau.kuhhandel.shared.model.MoneyCard
 import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.TradeState
 
 @Composable
 fun OtherFarm(
@@ -59,7 +65,7 @@ fun OtherFarm(
                 contentDescription = "OtherFarm",
                 modifier = Modifier.size(135.dp),
             )
-            // Money card count bubble - matching mockup look
+            // Money card count bubble - STRICTLY COUNT ONLY for others
             Surface(
                 color = PureWhite,
                 shape = MaterialTheme.shapes.medium,
@@ -201,6 +207,50 @@ fun AuctionView(auction: AuctionState?) {
 }
 
 @Composable
+fun AuctionControls(
+    onBid: (Int) -> Unit,
+    currentBid: Int,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.padding(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Button(onClick = { onBid(currentBid + 10) }) { Text("+10") }
+        Button(onClick = { onBid(currentBid + 50) }) { Text("+50") }
+        Button(onClick = { onBid(currentBid + 100) }) { Text("+100") }
+    }
+}
+
+@Composable
+fun TradeView(
+    trade: TradeState?,
+    onAccept: () -> Unit,
+    onCounter: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (trade == null) return
+
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
+        modifier = modifier.padding(16.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text("TRADE CHALLENGE", style = MaterialTheme.typography.titleMedium)
+            Text("For: ${trade.requestedAnimalType.name}")
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = onAccept) { Text("Accept") }
+                Button(onClick = onCounter) { Text("Counter") }
+            }
+        }
+    }
+}
+
+@Composable
 fun PlayerFarm(
     player: PlayerState?,
     isMyTurn: Boolean,
@@ -210,59 +260,123 @@ fun PlayerFarm(
         modifier =
             modifier
                 .fillMaxWidth()
-                .height(240.dp),
+                .height(IntrinsicSize.Min),
         contentAlignment = Alignment.BottomCenter,
     ) {
-        // The asset ig_farm_self contains both the fence (top) and roof (bottom)
-        Image(
-            painter = painterResource(id = R.drawable.ig_farm_self),
-            contentDescription = "My Farm Area",
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(220.dp),
-            contentScale = ContentScale.FillWidth,
-            alignment = Alignment.Center,
-        )
-
-        // Player Stats Overlay
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 16.dp, start = 24.dp, end = 24.dp),
-            verticalAlignment = Alignment.Bottom,
-            horizontalArrangement = Arrangement.SpaceBetween,
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            Column {
-                Text(
-                    text = player?.name ?: "YOU",
-                    style = MaterialTheme.typography.headlineMedium,
-                    color = WhitePurple,
-                    fontWeight = FontWeight.Black,
+            // Money Hand (Your own cards)
+            if (player != null) {
+                MoneyHand(
+                    cards = player.moneyCards,
+                    modifier = Modifier.padding(bottom = 8.dp),
                 )
-                if (isMyTurn) {
-                    Text(
-                        "YOUR TURN",
-                        style = MaterialTheme.typography.titleMedium,
-                        color = Color(0xFFFFEB3B), // Keep a bright yellow for attention
-                        fontWeight = FontWeight.ExtraBold,
-                    )
+            }
+
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(180.dp),
+                contentAlignment = Alignment.BottomCenter,
+            ) {
+                // The asset ig_farm_self contains both the fence (top) and roof (bottom)
+                Image(
+                    painter = painterResource(id = R.drawable.ig_farm_self),
+                    contentDescription = "My Farm Area",
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(180.dp),
+                    contentScale = ContentScale.FillWidth,
+                    alignment = Alignment.Center,
+                )
+
+                // Player Stats Overlay
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 16.dp, start = 24.dp, end = 24.dp),
+                    verticalAlignment = Alignment.Bottom,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column {
+                        Text(
+                            text = player?.name ?: "YOU",
+                            style = MaterialTheme.typography.headlineMedium,
+                            color = WhitePurple,
+                            fontWeight = FontWeight.Black,
+                        )
+                        if (isMyTurn) {
+                            Text(
+                                "YOUR TURN",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = Color(0xFFFFEB3B),
+                                fontWeight = FontWeight.ExtraBold,
+                            )
+                        }
+                    }
+
+                    Surface(
+                        color = DarkPurple.copy(alpha = 0.7f),
+                        shape = MaterialTheme.shapes.medium,
+                    ) {
+                        Text(
+                            "${player?.moneyCards?.size ?: 0} Cards | Total: ${player?.totalMoney() ?: 0}",
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                            style = MaterialTheme.typography.titleSmall,
+                            color = WhitePurple,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
                 }
             }
+        }
+    }
+}
 
-            Surface(
-                color = DarkPurple.copy(alpha = 0.7f),
-                shape = MaterialTheme.shapes.medium,
-            ) {
-                Text(
-                    "${player?.moneyCards?.size ?: 0} Cards | Total: ${player?.totalMoney() ?: 0}",
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                    style = MaterialTheme.typography.titleSmall,
-                    color = WhitePurple,
-                    fontWeight = FontWeight.Bold,
-                )
-            }
+@Composable
+fun MoneyHand(
+    cards: List<MoneyCard>,
+    modifier: Modifier = Modifier,
+    onCardClick: (MoneyCard) -> Unit = {},
+) {
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        items(cards) { card ->
+            MoneyCardView(
+                card = card,
+                onClick = { onCardClick(card) },
+                modifier = Modifier.padding(horizontal = 2.dp),
+            )
+        }
+    }
+}
+
+@Composable
+fun MoneyCardView(
+    card: MoneyCard,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        color = WhitePurple,
+        shape = MaterialTheme.shapes.small,
+        shadowElevation = 4.dp,
+        modifier = modifier.size(width = 60.dp, height = 90.dp).clickable { onClick() },
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = card.value.toString(),
+                style = MaterialTheme.typography.titleLarge,
+                color = DarkPurple,
+                fontWeight = FontWeight.Bold,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/GameComponents.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/GameComponents.kt
@@ -301,8 +301,7 @@ fun PlayerFarm(
     Box(
         modifier =
             modifier
-                .fillMaxWidth()
-                .height(IntrinsicSize.Min),
+                .fillMaxWidth(),
         contentAlignment = Alignment.BottomCenter,
     ) {
         Column(

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/GameComponents.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/GameComponents.kt
@@ -102,6 +102,7 @@ fun OtherFarm(
 fun OpponentList(
     players: List<PlayerState>,
     myId: String?,
+    onOpponentClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val opponents = players.filter { it.id != myId }
@@ -117,7 +118,11 @@ fun OpponentList(
                 rowPlayers.forEachIndexed { colIndex, player ->
                     val index = (rowIndex * 2) + colIndex
                     val color = FarmColor.entries[index % FarmColor.entries.size]
-                    OtherFarm(player = player, farmColor = color, onClick = {})
+                    OtherFarm(
+                        player = player,
+                        farmColor = color,
+                        onClick = { onOpponentClick(player.id) },
+                    )
                 }
             }
         }
@@ -192,7 +197,7 @@ fun AuctionView(
                     "Time left: ${it}s",
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.error,
-                    fontWeight = FontWeight.Bold
+                    fontWeight = FontWeight.Bold,
                 )
             }
 
@@ -223,7 +228,7 @@ fun AuctionView(
 fun AuctionControls(
     onBid: (Int) -> Unit,
     currentBid: Int,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = modifier.padding(16.dp),
@@ -240,12 +245,19 @@ fun TradeView(
     trade: TradeState?,
     onAccept: () -> Unit,
     onCounter: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    myId: String? = null,
 ) {
     if (trade == null) return
 
+    val isInitiator = trade.initiatingPlayerId == myId
+    val isChallenged = trade.challengedPlayerId == myId
+
     Card(
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            ),
         modifier = modifier.padding(16.dp),
     ) {
         Column(
@@ -254,10 +266,25 @@ fun TradeView(
         ) {
             Text("TRADE CHALLENGE", style = MaterialTheme.typography.titleMedium)
             Text("For: ${trade.requestedAnimalType.name}")
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            if (isInitiator) {
+                if (trade.offeredMoneyCardCount == 0) {
+                    Text("Select cards and send your offer")
+                } else {
+                    Text("Waiting for response...")
+                }
+            } else if (isChallenged) {
+                Text("Offer received: ${trade.offeredMoneyCardCount} cards")
+            }
+
             Spacer(modifier = Modifier.height(16.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Button(onClick = onAccept) { Text("Accept") }
-                Button(onClick = onCounter) { Text("Counter") }
+                if (isChallenged) {
+                    Button(onClick = onAccept) { Text("Accept") }
+                    Button(onClick = onCounter) { Text("Counter") }
+                }
             }
         }
     }
@@ -267,6 +294,8 @@ fun TradeView(
 fun PlayerFarm(
     player: PlayerState?,
     isMyTurn: Boolean,
+    selectedMoneyCardIds: Set<String> = emptySet(),
+    onCardClick: (MoneyCard) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -284,6 +313,8 @@ fun PlayerFarm(
             if (player != null) {
                 MoneyHand(
                     cards = player.moneyCards,
+                    selectedCardIds = selectedMoneyCardIds,
+                    onCardClick = onCardClick,
                     modifier = Modifier.padding(bottom = 8.dp),
                 )
             }
@@ -354,8 +385,9 @@ fun PlayerFarm(
 @Composable
 fun MoneyHand(
     cards: List<MoneyCard>,
-    modifier: Modifier = Modifier,
+    selectedCardIds: Set<String> = emptySet(),
     onCardClick: (MoneyCard) -> Unit = {},
+    modifier: Modifier = Modifier,
 ) {
     LazyRow(
         modifier = modifier.fillMaxWidth(),
@@ -364,6 +396,7 @@ fun MoneyHand(
         items(cards) { card ->
             MoneyCardView(
                 card = card,
+                isSelected = selectedCardIds.contains(card.id),
                 onClick = { onCardClick(card) },
                 modifier = Modifier.padding(horizontal = 2.dp),
             )
@@ -374,14 +407,20 @@ fun MoneyHand(
 @Composable
 fun MoneyCardView(
     card: MoneyCard,
+    isSelected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Surface(
-        color = WhitePurple,
+        color = if (isSelected) MaterialTheme.colorScheme.primaryContainer else WhitePurple,
         shape = MaterialTheme.shapes.small,
-        shadowElevation = 4.dp,
-        modifier = modifier.size(width = 60.dp, height = 90.dp).clickable { onClick() },
+        shadowElevation = if (isSelected) 8.dp else 4.dp,
+        modifier =
+            modifier
+                .size(width = 60.dp, height = 90.dp)
+                .offset(y = if (isSelected) (-10).dp else 0.dp)
+                .clickable { onClick() },
+        border = if (isSelected) BorderStroke(2.dp, MaterialTheme.colorScheme.primary) else null,
     ) {
         Box(contentAlignment = Alignment.Center) {
             Text(

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/GameComponents.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/GameComponents.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/GameComponents.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/GameComponents.kt
@@ -167,7 +167,10 @@ fun DeckView(
 }
 
 @Composable
-fun AuctionView(auction: AuctionState?) {
+fun AuctionView(
+    auction: AuctionState?,
+    timerSeconds: Int? = null,
+) {
     if (auction == null) return
 
     Card(
@@ -183,6 +186,16 @@ fun AuctionView(auction: AuctionState?) {
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text("LIVE AUCTION", style = MaterialTheme.typography.labelLarge)
+
+            timerSeconds?.let {
+                Text(
+                    "Time left: ${it}s",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
             Spacer(modifier = Modifier.height(12.dp))
 
             Image(

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
@@ -1,8 +1,10 @@
 package at.aau.kuhhandel.app.ui.game
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -18,11 +20,13 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import at.aau.kuhhandel.app.ui.components.AuctionControls
 import at.aau.kuhhandel.app.ui.components.AuctionView
 import at.aau.kuhhandel.app.ui.components.DeckView
 import at.aau.kuhhandel.app.ui.components.MainBackground
 import at.aau.kuhhandel.app.ui.components.OpponentList
 import at.aau.kuhhandel.app.ui.components.PlayerFarm
+import at.aau.kuhhandel.app.ui.components.TradeView
 import at.aau.kuhhandel.app.ui.components.getAnimalDrawable
 import at.aau.kuhhandel.shared.enums.GamePhase
 import at.aau.kuhhandel.shared.model.GameState
@@ -34,6 +38,9 @@ fun GameScreen(
     uiState: GameUiState,
     onStartGame: () -> Unit,
     onRevealCard: () -> Unit,
+    onPlaceBid: (Int) -> Unit,
+    onBuyBack: (Boolean) -> Unit,
+    onRespondToTrade: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     MainBackground(modifier = modifier)
@@ -44,7 +51,6 @@ fun GameScreen(
                 .fillMaxSize(),
     ) {
         // --- DECOR ---
-        // Left side bush
         Image(
             painter = painterResource(id = at.aau.kuhhandel.app.R.drawable.ig_short_bush),
             contentDescription = null,
@@ -55,7 +61,6 @@ fun GameScreen(
                     .size(60.dp),
             alpha = 0.6f,
         )
-        // Right side bush
         Image(
             painter = painterResource(id = at.aau.kuhhandel.app.R.drawable.ig_tall_bush),
             contentDescription = null,
@@ -64,17 +69,6 @@ fun GameScreen(
                     .align(Alignment.CenterEnd)
                     .padding(end = 32.dp, top = 420.dp)
                     .size(80.dp),
-            alpha = 0.6f,
-        )
-        // Bottom decor
-        Image(
-            painter = painterResource(id = at.aau.kuhhandel.app.R.drawable.ig_short_bush),
-            contentDescription = null,
-            modifier =
-                Modifier
-                    .align(Alignment.BottomStart)
-                    .padding(start = 40.dp, bottom = 220.dp)
-                    .size(70.dp),
             alpha = 0.6f,
         )
 
@@ -142,28 +136,28 @@ fun GameScreen(
                 }
 
                 GamePhase.AUCTION -> {
-                    AuctionView(uiState.gameState?.auctionState)
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        AuctionView(uiState.gameState?.auctionState)
+                        if (uiState.isConnected && !uiState.isAuctioneer) {
+                            AuctionControls(
+                                onBid = onPlaceBid,
+                                currentBid = uiState.gameState?.auctionState?.highestBid ?: 0,
+                            )
+                        } else if (uiState.isAuctioneer && (uiState.gameState?.auctionState?.isClosed == true)) {
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Button(onClick = { onBuyBack(true) }) { Text("Buy Back") }
+                                Button(onClick = { onBuyBack(false) }) { Text("Let Winner Buy") }
+                            }
+                        }
+                    }
                 }
 
                 GamePhase.TRADE -> {
-                    val trade = uiState.gameState?.tradeState
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text(
-                            "TRADE CHALLENGE",
-                            style = MaterialTheme.typography.headlineMedium,
-                            color = MaterialTheme.colorScheme.tertiary,
-                        )
-                        if (trade != null) {
-                            Text(
-                                "Between ${trade.initiatingPlayerId} and ${trade.challengedPlayerId}",
-                                style = MaterialTheme.typography.bodyLarge,
-                            )
-                            Text(
-                                "For: ${trade.requestedAnimalType.name}",
-                                style = MaterialTheme.typography.titleMedium,
-                            )
-                        }
-                    }
+                    TradeView(
+                        trade = uiState.gameState?.tradeState,
+                        onAccept = { onRespondToTrade(true) },
+                        onCounter = { onRespondToTrade(false) },
+                    )
                 }
 
                 GamePhase.FINISHED -> {
@@ -213,10 +207,14 @@ fun GameScreenPreview() {
             currentPhase = GamePhase.PLAYER_TURN,
             deckCountText = "5",
             canRevealCard = true,
+            myMoneyCards = players[4].moneyCards,
         )
     GameScreen(
         uiState = uiState,
         onStartGame = {},
         onRevealCard = {},
+        onPlaceBid = {},
+        onBuyBack = {},
+        onRespondToTrade = {},
     )
 }

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
@@ -11,11 +11,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,6 +34,7 @@ import at.aau.kuhhandel.app.ui.components.OpponentList
 import at.aau.kuhhandel.app.ui.components.PlayerFarm
 import at.aau.kuhhandel.app.ui.components.TradeView
 import at.aau.kuhhandel.app.ui.components.getAnimalDrawable
+import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.enums.GamePhase
 import at.aau.kuhhandel.shared.model.GameState
 import at.aau.kuhhandel.shared.model.MoneyCard
@@ -45,12 +48,37 @@ fun GameScreen(
     onPlaceBid: (Int) -> Unit,
     onBuyBack: (Boolean) -> Unit,
     onRespondToTrade: (Boolean) -> Unit,
-    onInitiateTrade: (String) -> Unit,
+    onInitiateTrade: (String, AnimalType) -> Unit,
+    onSelectTargetPlayer: (String?) -> Unit,
     onToggleMoneyCard: (String) -> Unit,
     onLeaveGame: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     MainBackground(modifier = modifier)
+
+    // --- ANIMAL SELECTION DIALOG ---
+    if (uiState.selectedTargetPlayerId != null) {
+        AlertDialog(
+            onDismissRequest = { onSelectTargetPlayer(null) },
+            title = { Text("Pick animal to trade") },
+            text = {
+                Column {
+                    if (uiState.sharedAnimalsWithSelectedPlayer.isEmpty()) {
+                        Text("No shared animals found.")
+                    } else {
+                        uiState.sharedAnimalsWithSelectedPlayer.forEach { animal ->
+                            TextButton(onClick = { onInitiateTrade(uiState.selectedTargetPlayerId, animal) }) {
+                                Text(animal.name)
+                            }
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { onSelectTargetPlayer(null) }) { Text("Cancel") }
+            },
+        )
+    }
 
     Box(
         modifier =
@@ -83,7 +111,7 @@ fun GameScreen(
         OpponentList(
             players = uiState.gameState?.players ?: emptyList(),
             myId = uiState.myPlayerId,
-            onOpponentClick = onInitiateTrade,
+            onOpponentClick = onSelectTargetPlayer,
             modifier =
                 Modifier
                     .align(Alignment.TopCenter)
@@ -272,7 +300,8 @@ fun GameScreenPreview() {
         onPlaceBid = {},
         onBuyBack = {},
         onRespondToTrade = {},
-        onInitiateTrade = {},
+        onInitiateTrade = { _, _ -> },
+        onSelectTargetPlayer = {},
         onToggleMoneyCard = {},
         onLeaveGame = {},
     )

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
@@ -9,7 +9,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -41,6 +45,9 @@ fun GameScreen(
     onPlaceBid: (Int) -> Unit,
     onBuyBack: (Boolean) -> Unit,
     onRespondToTrade: (Boolean) -> Unit,
+    onInitiateTrade: (String) -> Unit,
+    onToggleMoneyCard: (String) -> Unit,
+    onLeaveGame: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     MainBackground(modifier = modifier)
@@ -76,11 +83,24 @@ fun GameScreen(
         OpponentList(
             players = uiState.gameState?.players ?: emptyList(),
             myId = uiState.myPlayerId,
+            onOpponentClick = onInitiateTrade,
             modifier =
                 Modifier
                     .align(Alignment.TopCenter)
-                    .padding(top = 16.dp),
+                    .padding(top = 48.dp),
         )
+
+        // --- TOP RIGHT: EXIT ---
+        IconButton(
+            onClick = onLeaveGame,
+            modifier = Modifier.align(Alignment.TopEnd).padding(16.dp),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ExitToApp,
+                contentDescription = "Leave Game",
+                tint = Color.White,
+            )
+        }
 
         // --- CENTER: THE BOARD ---
         Box(
@@ -139,28 +159,59 @@ fun GameScreen(
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         AuctionView(
                             auction = uiState.gameState?.auctionState,
-                            timerSeconds = uiState.auctionTimerSeconds
+                            timerSeconds = uiState.auctionTimerSeconds,
                         )
-                        if (uiState.isConnected && !uiState.isAuctioneer && (uiState.gameState?.auctionState?.isClosed != true)) {
+                        if (uiState.isConnected &&
+                            !uiState.isAuctioneer &&
+                            (uiState.gameState?.auctionState?.isClosed != true)
+                        ) {
                             AuctionControls(
                                 onBid = onPlaceBid,
                                 currentBid = uiState.gameState?.auctionState?.highestBid ?: 0,
                             )
-                        } else if (uiState.isAuctioneer && (uiState.gameState?.auctionState?.isClosed == true)) {
-                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                Button(onClick = { onBuyBack(true) }) { Text("Buy Back") }
-                                Button(onClick = { onBuyBack(false) }) { Text("Let Winner Buy") }
+                        } else if (uiState.isAuctioneer &&
+                            (uiState.gameState?.auctionState?.isClosed == true)
+                        ) {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(
+                                    "Auction Closed. Choose your action:",
+                                    color = Color.White,
+                                    modifier = Modifier.padding(bottom = 8.dp),
+                                )
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    Button(onClick = { onBuyBack(true) }) { Text("Buy Back") }
+                                    Button(
+                                        onClick = { onBuyBack(false) },
+                                    ) { Text("Let Winner Buy") }
+                                }
                             }
                         }
                     }
                 }
 
                 GamePhase.TRADE -> {
-                    TradeView(
-                        trade = uiState.gameState?.tradeState,
-                        onAccept = { onRespondToTrade(true) },
-                        onCounter = { onRespondToTrade(false) },
-                    )
+                    val trade = uiState.gameState?.tradeState
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        TradeView(
+                            trade = trade,
+                            onAccept = { onRespondToTrade(true) },
+                            onCounter = { onRespondToTrade(false) },
+                            modifier = Modifier,
+                            myId = uiState.myPlayerId,
+                        )
+                        // If I am the initiator, I might need to send my first offer
+                        if (trade?.initiatingPlayerId == uiState.myPlayerId &&
+                            (trade?.offeredMoneyCardCount ?: 0) == 0
+                        ) {
+                            Button(
+                                onClick = { onRespondToTrade(true) },
+                                modifier = Modifier.padding(top = 8.dp),
+                                enabled = uiState.selectedMoneyCardIds.isNotEmpty(),
+                            ) {
+                                Text("Send Offer (${uiState.selectedMoneyCardIds.size})")
+                            }
+                        }
+                    }
                 }
 
                 GamePhase.FINISHED -> {
@@ -181,6 +232,8 @@ fun GameScreen(
         PlayerFarm(
             player = uiState.gameState?.players?.find { it.id == uiState.myPlayerId },
             isMyTurn = uiState.isMyTurn,
+            selectedMoneyCardIds = uiState.selectedMoneyCardIds,
+            onCardClick = { onToggleMoneyCard(it.id) },
             modifier = Modifier.align(Alignment.BottomCenter),
         )
     }
@@ -219,5 +272,8 @@ fun GameScreenPreview() {
         onPlaceBid = {},
         onBuyBack = {},
         onRespondToTrade = {},
+        onInitiateTrade = {},
+        onToggleMoneyCard = {},
+        onLeaveGame = {},
     )
 }

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
@@ -67,7 +67,14 @@ fun GameScreen(
                         Text("No shared animals found.")
                     } else {
                         uiState.sharedAnimalsWithSelectedPlayer.forEach { animal ->
-                            TextButton(onClick = { onInitiateTrade(uiState.selectedTargetPlayerId, animal) }) {
+                            TextButton(
+                                onClick = {
+                                    onInitiateTrade(
+                                        uiState.selectedTargetPlayerId,
+                                        animal,
+                                    )
+                                },
+                            ) {
                                 Text(animal.name)
                             }
                         }

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
@@ -137,8 +137,11 @@ fun GameScreen(
 
                 GamePhase.AUCTION -> {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        AuctionView(uiState.gameState?.auctionState)
-                        if (uiState.isConnected && !uiState.isAuctioneer) {
+                        AuctionView(
+                            auction = uiState.gameState?.auctionState,
+                            timerSeconds = uiState.auctionTimerSeconds
+                        )
+                        if (uiState.isConnected && !uiState.isAuctioneer && (uiState.gameState?.auctionState?.isClosed != true)) {
                             AuctionControls(
                                 onBid = onPlaceBid,
                                 currentBid = uiState.gameState?.auctionState?.highestBid ?: 0,

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
@@ -149,8 +149,13 @@ fun GameScreen(
                             Text("START MATCH")
                         }
                     } else {
+                        val message = if (uiState.gameState?.hostPlayerId == uiState.myPlayerId) {
+                            "Waiting for players (min. 3)..."
+                        } else {
+                            "Waiting for host to start..."
+                        }
                         Text(
-                            "Waiting for host to start...",
+                            text = message,
                             style = MaterialTheme.typography.headlineSmall,
                             color = Color.White,
                         )

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
@@ -149,11 +149,12 @@ fun GameScreen(
                             Text("START MATCH")
                         }
                     } else {
-                        val message = if (uiState.gameState?.hostPlayerId == uiState.myPlayerId) {
-                            "Waiting for players (min. 3)..."
-                        } else {
-                            "Waiting for host to start..."
-                        }
+                        val message =
+                            if (uiState.gameState?.hostPlayerId == uiState.myPlayerId) {
+                                "Waiting for players (min. 3)..."
+                            } else {
+                                "Waiting for host to start..."
+                            }
                         Text(
                             text = message,
                             style = MaterialTheme.typography.headlineSmall,

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameViewModel.kt
@@ -166,7 +166,17 @@ class GameViewModel(
     fun respondToTrade(accepted: Boolean) {
         scope.launch {
             try {
-                repository.respondToTrade(accepted)
+                // For minimal actions, we just send empty list or could add selection logic later
+                repository.respondToTrade(accepted, emptyList())
+            } catch (e: Exception) {
+            }
+        }
+    }
+
+    fun initiateTrade(targetPlayerId: String) {
+        scope.launch {
+            try {
+                repository.initiateTrade(targetPlayerId, emptyList())
             } catch (e: Exception) {
             }
         }

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameViewModel.kt
@@ -105,13 +105,29 @@ class GameViewModel(
             val gameState = repoState.gameState
             val currentPhase = gameState?.phase ?: GamePhase.NOT_STARTED
 
-            val sharedAnimals = if (targetId != null && gameState != null && repoState.myPlayerId != null) {
-                val myAnimals = gameState.players.find { it.id == repoState.myPlayerId }?.animals?.map { it.type }?.toSet() ?: emptySet()
-                val targetAnimals = gameState.players.find { it.id == targetId }?.animals?.map { it.type }?.toSet() ?: emptySet()
-                myAnimals.intersect(targetAnimals).toList()
-            } else {
-                emptyList()
-            }
+            val sharedAnimals =
+                if (targetId != null &&
+                    gameState != null &&
+                    repoState.myPlayerId != null
+                ) {
+                    val myAnimals =
+                        gameState.players
+                            .find { it.id == repoState.myPlayerId }
+                            ?.animals
+                            ?.map { it.type }
+                            ?.toSet()
+                            ?: emptySet()
+                    val targetAnimals =
+                        gameState.players
+                            .find { it.id == targetId }
+                            ?.animals
+                            ?.map { it.type }
+                            ?.toSet()
+                            ?: emptySet()
+                    myAnimals.intersect(targetAnimals).toList()
+                } else {
+                    emptyList()
+                }
 
             GameUiState(
                 gameState = gameState,
@@ -222,10 +238,17 @@ class GameViewModel(
         }
     }
 
-    fun initiateTrade(targetPlayerId: String, animalType: AnimalType) {
+    fun initiateTrade(
+        targetPlayerId: String,
+        animalType: AnimalType,
+    ) {
         scope.launch {
             try {
-                repository.initiateTrade(targetPlayerId, animalType, selectedMoneyCardIds.value.toList())
+                repository.initiateTrade(
+                    targetPlayerId,
+                    animalType,
+                    selectedMoneyCardIds.value.toList(),
+                )
                 clearSelection()
                 selectedTargetPlayerId.value = null
             } catch (_: Exception) {

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameViewModel.kt
@@ -32,11 +32,15 @@ data class GameUiState(
     val canStartGame: Boolean = false,
     val auctionTimerSeconds: Int? = null,
     val errorMessage: String? = null,
+    val myMoneyCards: List<at.aau.kuhhandel.shared.model.MoneyCard> = emptyList(),
 ) {
     val isMyTurn: Boolean get() =
         gameState?.currentPlayerIndex?.let {
             gameState.players.getOrNull(it)?.id == myPlayerId
         } ?: false
+
+    val isAuctioneer: Boolean get() =
+        gameState?.auctionState?.auctioneerId == myPlayerId
 
     val activePlayerName: String get() =
         gameState?.let {
@@ -98,15 +102,16 @@ class GameViewModel(
                     } ?: "No card revealed",
                 isConnected = repoState.isConnected,
                 canRevealCard =
-                    repoState.isConnected &&
+                    (repoState.isConnected &&
                         currentPhase == GamePhase.PLAYER_TURN &&
                         (
                             gameState?.players?.getOrNull(gameState.currentPlayerIndex)?.id ==
                                 repoState.myPlayerId
-                        ),
+                        )),
                 canStartGame = repoState.isConnected && currentPhase == GamePhase.NOT_STARTED,
                 errorMessage = repoState.errorMessage,
                 auctionTimerSeconds = timer,
+                myMoneyCards = gameState?.players?.find { it.id == repoState.myPlayerId }?.moneyCards ?: emptyList(),
             )
         }.stateIn(
             scope = scope,
@@ -149,12 +154,20 @@ class GameViewModel(
         }
     }
 
-    fun initiateTrade(targetPlayerId: String) {
+    fun offerTrade(moneyCardIds: List<String>) {
         scope.launch {
             try {
-                repository.initiateTrade(targetPlayerId)
+                repository.offerTrade(moneyCardIds)
             } catch (e: Exception) {
-                // Error handled by repository
+            }
+        }
+    }
+
+    fun respondToTrade(accepted: Boolean) {
+        scope.launch {
+            try {
+                repository.respondToTrade(accepted)
+            } catch (e: Exception) {
             }
         }
     }

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameViewModel.kt
@@ -148,7 +148,11 @@ class GameViewModel(
                                     repoState.myPlayerId
                             )
                     ),
-                canStartGame = repoState.isConnected && currentPhase == GamePhase.NOT_STARTED,
+                canStartGame =
+                    repoState.isConnected &&
+                        currentPhase == GamePhase.NOT_STARTED &&
+                        (gameState?.players?.size ?: 0) >= 3 &&
+                        gameState?.hostPlayerId == repoState.myPlayerId,
                 errorMessage = repoState.errorMessage,
                 auctionTimerSeconds = timer,
                 myMoneyCards =

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameViewModel.kt
@@ -1,6 +1,7 @@
 package at.aau.kuhhandel.app.ui.game
 
 import at.aau.kuhhandel.app.network.game.GameRepository
+import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.enums.GamePhase
 import at.aau.kuhhandel.shared.model.GameState
 import kotlinx.coroutines.CoroutineScope
@@ -36,6 +37,8 @@ data class GameUiState(
     val errorMessage: String? = null,
     val myMoneyCards: List<at.aau.kuhhandel.shared.model.MoneyCard> = emptyList(),
     val selectedMoneyCardIds: Set<String> = emptySet(),
+    val sharedAnimalsWithSelectedPlayer: List<AnimalType> = emptyList(),
+    val selectedTargetPlayerId: String? = null,
 ) {
     val isMyTurn: Boolean get() =
         gameState?.currentPlayerIndex?.let {
@@ -69,6 +72,7 @@ class GameViewModel(
     private val timeProvider: TimeProvider = SystemTimeProvider(),
 ) {
     private val selectedMoneyCardIds = MutableStateFlow<Set<String>>(emptySet())
+    private val selectedTargetPlayerId = MutableStateFlow<String?>(null)
 
     private val auctionTimerSeconds =
         repository.state
@@ -96,9 +100,18 @@ class GameViewModel(
             repository.state,
             auctionTimerSeconds,
             selectedMoneyCardIds,
-        ) { repoState, timer, selectedIds ->
+            selectedTargetPlayerId,
+        ) { repoState, timer, selectedIds, targetId ->
             val gameState = repoState.gameState
             val currentPhase = gameState?.phase ?: GamePhase.NOT_STARTED
+
+            val sharedAnimals = if (targetId != null && gameState != null && repoState.myPlayerId != null) {
+                val myAnimals = gameState.players.find { it.id == repoState.myPlayerId }?.animals?.map { it.type }?.toSet() ?: emptySet()
+                val targetAnimals = gameState.players.find { it.id == targetId }?.animals?.map { it.type }?.toSet() ?: emptySet()
+                myAnimals.intersect(targetAnimals).toList()
+            } else {
+                emptyList()
+            }
 
             GameUiState(
                 gameState = gameState,
@@ -126,6 +139,8 @@ class GameViewModel(
                     gameState?.players?.find { it.id == repoState.myPlayerId }?.moneyCards
                         ?: emptyList(),
                 selectedMoneyCardIds = selectedIds,
+                sharedAnimalsWithSelectedPlayer = sharedAnimals,
+                selectedTargetPlayerId = targetId,
             )
         }.stateIn(
             scope = scope,
@@ -178,7 +193,7 @@ class GameViewModel(
         }
     }
 
-    fun offerTrade() {
+    private fun offerTrade() {
         scope.launch {
             try {
                 repository.offerTrade(selectedMoneyCardIds.value.toList())
@@ -207,13 +222,18 @@ class GameViewModel(
         }
     }
 
-    fun initiateTrade(targetPlayerId: String) {
+    fun initiateTrade(targetPlayerId: String, animalType: AnimalType) {
         scope.launch {
             try {
-                repository.initiateTrade(targetPlayerId, selectedMoneyCardIds.value.toList())
+                repository.initiateTrade(targetPlayerId, animalType, selectedMoneyCardIds.value.toList())
                 clearSelection()
+                selectedTargetPlayerId.value = null
             } catch (_: Exception) {
             }
         }
+    }
+
+    fun selectTargetPlayer(playerId: String?) {
+        selectedTargetPlayerId.value = playerId
     }
 }

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameViewModel.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameViewModel.kt
@@ -6,6 +6,7 @@ import at.aau.kuhhandel.shared.model.GameState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -15,6 +16,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 /**
@@ -33,6 +35,7 @@ data class GameUiState(
     val auctionTimerSeconds: Int? = null,
     val errorMessage: String? = null,
     val myMoneyCards: List<at.aau.kuhhandel.shared.model.MoneyCard> = emptyList(),
+    val selectedMoneyCardIds: Set<String> = emptySet(),
 ) {
     val isMyTurn: Boolean get() =
         gameState?.currentPlayerIndex?.let {
@@ -65,6 +68,8 @@ class GameViewModel(
     private val scope: CoroutineScope,
     private val timeProvider: TimeProvider = SystemTimeProvider(),
 ) {
+    private val selectedMoneyCardIds = MutableStateFlow<Set<String>>(emptySet())
+
     private val auctionTimerSeconds =
         repository.state
             .map { it.gameState?.auctionState?.timerEndTime }
@@ -87,7 +92,11 @@ class GameViewModel(
             }
 
     val uiState: StateFlow<GameUiState> =
-        combine(repository.state, auctionTimerSeconds) { repoState, timer ->
+        combine(
+            repository.state,
+            auctionTimerSeconds,
+            selectedMoneyCardIds,
+        ) { repoState, timer, selectedIds ->
             val gameState = repoState.gameState
             val currentPhase = gameState?.phase ?: GamePhase.NOT_STARTED
 
@@ -102,22 +111,37 @@ class GameViewModel(
                     } ?: "No card revealed",
                 isConnected = repoState.isConnected,
                 canRevealCard =
-                    (repoState.isConnected &&
-                        currentPhase == GamePhase.PLAYER_TURN &&
-                        (
-                            gameState?.players?.getOrNull(gameState.currentPlayerIndex)?.id ==
-                                repoState.myPlayerId
-                        )),
+                    (
+                        repoState.isConnected &&
+                            currentPhase == GamePhase.PLAYER_TURN &&
+                            (
+                                gameState?.players?.getOrNull(gameState.currentPlayerIndex)?.id ==
+                                    repoState.myPlayerId
+                            )
+                    ),
                 canStartGame = repoState.isConnected && currentPhase == GamePhase.NOT_STARTED,
                 errorMessage = repoState.errorMessage,
                 auctionTimerSeconds = timer,
-                myMoneyCards = gameState?.players?.find { it.id == repoState.myPlayerId }?.moneyCards ?: emptyList(),
+                myMoneyCards =
+                    gameState?.players?.find { it.id == repoState.myPlayerId }?.moneyCards
+                        ?: emptyList(),
+                selectedMoneyCardIds = selectedIds,
             )
         }.stateIn(
             scope = scope,
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = GameUiState(),
         )
+
+    fun toggleMoneyCardSelection(cardId: String) {
+        selectedMoneyCardIds.update { current ->
+            if (current.contains(cardId)) current - cardId else current + cardId
+        }
+    }
+
+    fun clearSelection() {
+        selectedMoneyCardIds.value = emptySet()
+    }
 
     fun startGame() {
         scope.launch {
@@ -138,7 +162,7 @@ class GameViewModel(
         scope.launch {
             try {
                 repository.placeBid(amount)
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Error handled by repository
             }
         }
@@ -148,17 +172,18 @@ class GameViewModel(
         scope.launch {
             try {
                 repository.buyBack(buyBack)
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Error handled by repository
             }
         }
     }
 
-    fun offerTrade(moneyCardIds: List<String>) {
+    fun offerTrade() {
         scope.launch {
             try {
-                repository.offerTrade(moneyCardIds)
-            } catch (e: Exception) {
+                repository.offerTrade(selectedMoneyCardIds.value.toList())
+                clearSelection()
+            } catch (_: Exception) {
             }
         }
     }
@@ -166,9 +191,18 @@ class GameViewModel(
     fun respondToTrade(accepted: Boolean) {
         scope.launch {
             try {
-                // For minimal actions, we just send empty list or could add selection logic later
-                repository.respondToTrade(accepted, emptyList())
-            } catch (e: Exception) {
+                if (uiState.value.gameState
+                        ?.tradeState
+                        ?.initiatingPlayerId ==
+                    uiState.value.myPlayerId
+                ) {
+                    // If I'm the initiator, use offerTrade logic
+                    repository.offerTrade(selectedMoneyCardIds.value.toList())
+                } else {
+                    repository.respondToTrade(accepted, selectedMoneyCardIds.value.toList())
+                }
+                clearSelection()
+            } catch (_: Exception) {
             }
         }
     }
@@ -176,8 +210,9 @@ class GameViewModel(
     fun initiateTrade(targetPlayerId: String) {
         scope.launch {
             try {
-                repository.initiateTrade(targetPlayerId, emptyList())
-            } catch (e: Exception) {
+                repository.initiateTrade(targetPlayerId, selectedMoneyCardIds.value.toList())
+                clearSelection()
+            } catch (_: Exception) {
             }
         }
     }

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/joining/LobbyJoiningViewModel.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/joining/LobbyJoiningViewModel.kt
@@ -59,7 +59,7 @@ class LobbyJoiningViewModel(
             localErrorMessage.value = null
             scope.launch {
                 try {
-                    repository.createGame() // Placeholder for joinGame
+                    repository.joinGame(code) // re-check this! Fix placeholder
                     isLoading.value = false
                 } catch (e: Exception) {
                     isLoading.value = false

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/joining/LobbyJoiningViewModel.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/joining/LobbyJoiningViewModel.kt
@@ -59,7 +59,7 @@ class LobbyJoiningViewModel(
             localErrorMessage.value = null
             scope.launch {
                 try {
-                    repository.joinGame(code) // re-check this! Fix placeholder
+                    repository.joinGame(code)
                     isLoading.value = false
                 } catch (e: Exception) {
                     isLoading.value = false

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/joining/LobbyJoiningViewModel.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/joining/LobbyJoiningViewModel.kt
@@ -57,9 +57,15 @@ class LobbyJoiningViewModel(
         if (code.length == 5) {
             isLoading.value = true
             localErrorMessage.value = null
+            repository.clearError()
             scope.launch {
                 try {
                     repository.joinGame(code)
+                    // We don't set isLoading to false here immediately,
+                    // because we wait for the repository state to update
+                    // either with a gameId (success) or an errorMessage (failure).
+                    // However, to avoid being stuck in loading if something fails silently:
+                    kotlinx.coroutines.delay(1000)
                     isLoading.value = false
                 } catch (e: Exception) {
                     isLoading.value = false

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/lobby/LobbyViewModel.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/lobby/LobbyViewModel.kt
@@ -67,7 +67,8 @@ class LobbyViewModel(
                     canStartGame =
                         repoState.isConnected &&
                             isHost &&
-                            (gameState?.phase == GamePhase.NOT_STARTED || gameState == null),
+                            (gameState?.phase == GamePhase.NOT_STARTED || gameState == null) &&
+                            (gameState?.players?.size ?: 0) >= 2,
                 )
             }.stateIn(
                 scope = scope,

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/FakeWebSocketSession.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/FakeWebSocketSession.kt
@@ -53,6 +53,10 @@ internal class FakeWebSocketSession : WebSocketSession {
         incomingChannel.close()
     }
 
+    fun deliverError(cause: Throwable) {
+        incomingChannel.close(cause)
+    }
+
     fun onlySentEnvelope(): WebSocketEnvelope {
         val text = sentFrames.filterIsInstance<Frame.Text>().single()
         return WebSocketJson.json.decodeFromString(WebSocketEnvelope.serializer(), text.readText())

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
@@ -406,10 +406,11 @@ class GameRepositoryTest {
             harness.session.deliverEnvelope(
                 WebSocketEnvelope(
                     type = WebSocketType.GAME_JOINED,
-                    payload = WebSocketJson.json.encodeToJsonElement(
-                        GameStatePayload.serializer(),
-                        GameStatePayload(state = sampleState())
-                    ),
+                    payload =
+                        WebSocketJson.json.encodeToJsonElement(
+                            GameStatePayload.serializer(),
+                            GameStatePayload(state = sampleState()),
+                        ),
                 ),
             )
             flushRepository()

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
@@ -401,6 +401,21 @@ class GameRepositoryTest {
                 harness.state.errorMessage,
             )
 
+            // REPRODUCE USER ISSUE: GAME_JOINED with GameStatePayload (missing gameId)
+            // The repository should now handle this gracefully via fallback
+            harness.session.deliverEnvelope(
+                WebSocketEnvelope(
+                    type = WebSocketType.GAME_JOINED,
+                    payload = WebSocketJson.json.encodeToJsonElement(
+                        GameStatePayload.serializer(),
+                        GameStatePayload(state = sampleState())
+                    ),
+                ),
+            )
+            flushRepository()
+            assertNull(harness.state.errorMessage)
+            assertEquals("unknown", harness.state.gameId)
+
             // Invalid payload for ERROR
             harness.session.deliverEnvelope(
                 WebSocketEnvelope(

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
@@ -308,7 +308,7 @@ class GameRepositoryTest {
             // Missing payload
             harness.session.deliverEnvelope(WebSocketEnvelope(type = WebSocketType.GAME_CREATED))
             flushRepository()
-            assertEquals("Invalid GAME_CREATED message", harness.state.errorMessage)
+            assertEquals("Invalid GAME_CREATED/JOINED message", harness.state.errorMessage)
 
             // Invalid payload for GAME_STARTED
             harness.session.deliverEnvelope(

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
@@ -228,7 +228,7 @@ class GameRepositoryTest {
             )
             assertEquals(1, openCount)
 
-            harness.receiveGameState(WebSocketType.GAME_STARTED, startedState)
+            harness.receiveGameState(WebSocketType.GAME_STATE_UPDATED, startedState)
 
             assertEquals(startedState, harness.state.gameState)
             assertTrue(harness.state.isConnected)
@@ -388,10 +388,10 @@ class GameRepositoryTest {
                 harness.state.errorMessage,
             )
 
-            // Invalid payload for GAME_STARTED
+            // Invalid payload for GAME_STATE_UPDATED
             harness.session.deliverEnvelope(
                 WebSocketEnvelope(
-                    type = WebSocketType.GAME_STARTED,
+                    type = WebSocketType.GAME_STATE_UPDATED,
                     payload = WebSocketJson.json.parseToJsonElement("{}"),
                 ),
             )

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
@@ -267,6 +267,54 @@ class GameRepositoryTest {
     }
 
     @Test
+    fun `joinGame sends request`() {
+        runBlocking {
+            val harness = createHarness()
+            harness.repository.joinGame("g1", "p1")
+            assertEquals(WebSocketType.JOIN_GAME, harness.sentEnvelope().type)
+        }
+    }
+
+    @Test
+    fun `offerTrade sends request`() {
+        runBlocking {
+            val harness = createHarness()
+            harness.repository.offerTrade(listOf("m1"))
+            assertEquals(WebSocketType.OFFER_TRADE, harness.sentEnvelope().type)
+        }
+    }
+
+    @Test
+    fun `respondToTrade sends request`() {
+        runBlocking {
+            val harness = createHarness()
+            // Need myPlayerId to respond
+            harness.receiveGameCreated("g1", sampleState())
+
+            harness.repository.respondToTrade(true, listOf("m2"))
+            assertEquals(WebSocketType.RESPOND_TO_TRADE, harness.sentEnvelope().type)
+        }
+    }
+
+    @Test
+    fun `leaveGame sends request and disconnects`() {
+        runBlocking {
+            val harness = createHarness()
+            harness.createGame()
+            harness.repository.leaveGame()
+
+            assertEquals(
+                WebSocketType.LEAVE_GAME,
+                harness.session
+                    .sentEnvelopes()
+                    .last()
+                    .type,
+            )
+            assertFalse(harness.state.isConnected)
+        }
+    }
+
+    @Test
     fun `buyBack sends request`() {
         runBlocking {
             val harness = createHarness()
@@ -296,6 +344,33 @@ class GameRepositoryTest {
 
             harness.clearError()
             assertNull(harness.state.errorMessage)
+        }
+    }
+
+    @Test
+    fun `GAME_JOINED updates state`() {
+        runBlocking {
+            val harness = createHarness()
+            val state = sampleState()
+
+            harness.repository.createGame("me") // Ensure connected and setup
+
+            // Re-create the envelope manually to ensure correct requestId is NOT checked (handleEnvelope ignores it for JOINED)
+            val envelope =
+                WebSocketEnvelope(
+                    type = WebSocketType.GAME_JOINED,
+                    payload =
+                        WebSocketJson.json.encodeToJsonElement(
+                            GameCreatedPayload.serializer(),
+                            GameCreatedPayload(gameId = "g1", playerId = "me", state = state),
+                        ),
+                )
+
+            harness.session.deliverEnvelope(envelope)
+            flushRepository()
+
+            assertEquals("g1", harness.state.gameId)
+            assertEquals(state, harness.state.gameState)
         }
     }
 
@@ -370,6 +445,21 @@ class GameRepositoryTest {
                 "Connection lost: IllegalStateException - WebSocket closed (1000): bye",
                 harness.state.errorMessage,
             )
+        }
+    }
+
+    @Test
+    fun `collector failure reports error`() {
+        runBlocking {
+            val session = FakeWebSocketSession()
+            val harness = createHarness(session = session)
+            harness.createGame()
+
+            // Simulate exception in flow collection
+            session.deliverError(RuntimeException("crash"))
+            flushRepository()
+
+            assertEquals("Connection lost: RuntimeException - crash", harness.state.errorMessage)
         }
     }
 

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
@@ -55,8 +55,11 @@ class GameRepositoryTest {
             repository.buyBack(buyBack)
         }
 
-        suspend fun initiateTrade(targetPlayerId: String) {
-            repository.initiateTrade(targetPlayerId)
+        suspend fun initiateTrade(
+            targetPlayerId: String,
+            animalType: AnimalType = AnimalType.COW,
+        ) {
+            repository.initiateTrade(targetPlayerId, animalType)
         }
 
         fun clearError() {
@@ -147,7 +150,7 @@ class GameRepositoryTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     GameCreatedPayload.serializer(),
-                    GameCreatedPayload(gameId = gameId, state = state),
+                    GameCreatedPayload(gameId = gameId, playerId = "me", state = state),
                 ),
         )
 

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
@@ -383,7 +383,10 @@ class GameRepositoryTest {
             // Missing payload
             harness.session.deliverEnvelope(WebSocketEnvelope(type = WebSocketType.GAME_CREATED))
             flushRepository()
-            assertEquals("Invalid GAME_CREATED/JOINED message", harness.state.errorMessage)
+            assertEquals(
+                "Invalid GAME_CREATED/JOINED message (Payload is null for GAME_CREATED). Payload: null",
+                harness.state.errorMessage,
+            )
 
             // Invalid payload for GAME_STARTED
             harness.session.deliverEnvelope(
@@ -393,7 +396,10 @@ class GameRepositoryTest {
                 ),
             )
             flushRepository()
-            assertEquals("Invalid GameState message", harness.state.errorMessage)
+            assertEquals(
+                "Invalid GameState message (Field 'state' is required for type with serial name 'at.aau.kuhhandel.shared.websocket.GameStatePayload', but it was missing). Payload: {}",
+                harness.state.errorMessage,
+            )
 
             // Invalid payload for ERROR
             harness.session.deliverEnvelope(
@@ -403,7 +409,10 @@ class GameRepositoryTest {
                 ),
             )
             flushRepository()
-            assertEquals("Invalid ERROR message", harness.state.errorMessage)
+            assertEquals(
+                "Invalid ERROR message (Field 'message' is required for type with serial name 'at.aau.kuhhandel.shared.websocket.ErrorPayload', but it was missing). Payload: {}",
+                harness.state.errorMessage,
+            )
         }
     }
 

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClientTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClientTest.kt
@@ -180,6 +180,34 @@ class GameWebSocketClientTest {
     }
 
     @Test
+    fun `joinGame without connect throws`() {
+        runBlocking {
+            assertFailsWith<IllegalStateException> { client.joinGame("g1") }
+        }
+    }
+
+    @Test
+    fun `leaveGame without connect throws`() {
+        runBlocking {
+            assertFailsWith<IllegalStateException> { client.leaveGame() }
+        }
+    }
+
+    @Test
+    fun `offerTrade without connect throws`() {
+        runBlocking {
+            assertFailsWith<IllegalStateException> { client.offerTrade(listOf("m1")) }
+        }
+    }
+
+    @Test
+    fun `respondToTrade without connect throws`() {
+        runBlocking {
+            assertFailsWith<IllegalStateException> { client.respondToTrade("p1", true) }
+        }
+    }
+
+    @Test
     fun `disconnect without connect does not throw`() {
         runBlocking {
             client.disconnect()
@@ -286,6 +314,46 @@ class GameWebSocketClientTest {
             assertEquals(requestId, sent.requestId)
             assertNotNull(sent.payload)
 
+            connection.disconnect()
+        }
+    }
+
+    @Test
+    fun `joinGame sends envelope with payload`() {
+        runBlocking {
+            val connection = connectClient()
+            client.joinGame("g1", "p1")
+            assertEquals(WebSocketType.JOIN_GAME, connection.session.onlySentEnvelope().type)
+            connection.disconnect()
+        }
+    }
+
+    @Test
+    fun `leaveGame sends envelope`() {
+        runBlocking {
+            val connection = connectClient()
+            client.leaveGame()
+            assertEquals(WebSocketType.LEAVE_GAME, connection.session.onlySentEnvelope().type)
+            connection.disconnect()
+        }
+    }
+
+    @Test
+    fun `offerTrade sends envelope with payload`() {
+        runBlocking {
+            val connection = connectClient()
+            client.offerTrade(listOf("m1"))
+            assertEquals(WebSocketType.OFFER_TRADE, connection.session.onlySentEnvelope().type)
+            connection.disconnect()
+        }
+    }
+
+    @Test
+    fun `respondToTrade sends envelope with payload`() {
+        runBlocking {
+            val connection = connectClient()
+            client.respondToTrade("p1", true, listOf("m2"))
+            assertEquals(WebSocketType.RESPOND_TO_TRADE, connection.session.onlySentEnvelope().type)
             connection.disconnect()
         }
     }

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClientTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClientTest.kt
@@ -1,5 +1,6 @@
 package at.aau.kuhhandel.app.network.game
 
+import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.websocket.CreateGamePayload
 import at.aau.kuhhandel.shared.websocket.WebSocketEnvelope
 import at.aau.kuhhandel.shared.websocket.WebSocketJson
@@ -174,7 +175,7 @@ class GameWebSocketClientTest {
     @Test
     fun `initiateTrade without connect throws`() {
         runBlocking {
-            assertFailsWith<IllegalStateException> { client.initiateTrade("p2") }
+            assertFailsWith<IllegalStateException> { client.initiateTrade("p2", AnimalType.COW) }
         }
     }
 
@@ -278,7 +279,7 @@ class GameWebSocketClientTest {
         runBlocking {
             val connection = connectClient()
 
-            val requestId = client.initiateTrade("player-456")
+            val requestId = client.initiateTrade("player-456", AnimalType.COW)
             val sent = connection.session.onlySentEnvelope()
 
             assertEquals(WebSocketType.INITIATE_TRADE, sent.type)

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClientTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameWebSocketClientTest.kt
@@ -409,7 +409,7 @@ class GameWebSocketClientTest {
                     assertFailsWith<IllegalStateException> {
                         events.await()
                     }
-                assertTrue(e.message?.contains("Kein Grund angegeben") == true)
+                assertTrue(e.message?.contains("No reason given") == true)
             }
         }
     }

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/GameViewModelTest.kt
@@ -195,16 +195,66 @@ class GameViewModelTest {
                 viewModel.uiState.collect {}
             }
 
-            // Case 1: Connected + NOT_STARTED -> True
+            // Case 1: Connected + NOT_STARTED + 3 Players + Host -> True
             repoStateFlow.value =
                 GameRepositoryState(
                     isConnected = true,
-                    gameState = GameState(phase = GamePhase.NOT_STARTED),
+                    myPlayerId = "host-id",
+                    gameState =
+                        GameState(
+                            phase = GamePhase.NOT_STARTED,
+                            players =
+                                listOf(
+                                    PlayerState("host-id", "Host"),
+                                    PlayerState("p2", "P2"),
+                                    PlayerState("p3", "P3"),
+                                ),
+                            hostPlayerId = "host-id",
+                        ),
                 )
             advanceUntilIdle()
             assertTrue(viewModel.uiState.value.canStartGame)
 
-            // Case 2: Connected + PLAYER_TURN -> False
+            // Case 2: Connected + NOT_STARTED + 3 Players + NOT Host -> False
+            repoStateFlow.value =
+                GameRepositoryState(
+                    isConnected = true,
+                    myPlayerId = "p2",
+                    gameState =
+                        GameState(
+                            phase = GamePhase.NOT_STARTED,
+                            players =
+                                listOf(
+                                    PlayerState("host-id", "Host"),
+                                    PlayerState("p2", "P2"),
+                                    PlayerState("p3", "P3"),
+                                ),
+                            hostPlayerId = "host-id",
+                        ),
+                )
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.canStartGame)
+
+            // Case 3: Connected + NOT_STARTED + 2 Players + Host -> False
+            repoStateFlow.value =
+                GameRepositoryState(
+                    isConnected = true,
+                    myPlayerId = "host-id",
+                    gameState =
+                        GameState(
+                            phase = GamePhase.NOT_STARTED,
+                            players =
+                                listOf(
+                                    PlayerState("host-id", "Host"),
+                                    PlayerState("p2", "P2"),
+                                ),
+                            hostPlayerId = "host-id",
+                        ),
+                )
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.canStartGame)
+
+            // Case 4: Connected + PLAYER_TURN -> False
             repoStateFlow.value =
                 GameRepositoryState(
                     isConnected = true,

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/GameViewModelTest.kt
@@ -256,11 +256,11 @@ class GameViewModelTest {
     @Test
     fun `initiateTrade calls repository and handles error`() {
         runTest {
-            coEvery { mockRepository.initiateTrade("player-2") } throws
+            coEvery { mockRepository.initiateTrade("player-2", AnimalType.COW, any()) } throws
                 RuntimeException("Network error")
-            viewModel.initiateTrade("player-2")
+            viewModel.initiateTrade("player-2", AnimalType.COW)
             advanceUntilIdle()
-            coVerify { mockRepository.initiateTrade("player-2") }
+            coVerify { mockRepository.initiateTrade("player-2", AnimalType.COW, any()) }
         }
     }
 

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/LobbyJoiningViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/LobbyJoiningViewModelTest.kt
@@ -117,8 +117,7 @@ class LobbyJoiningViewModelTest {
             viewModel.joinLobby()
             advanceUntilIdle()
 
-            // Based on current implementation using createGame as placeholder
-            coVerify { mockRepository.createGame() }
+            coVerify { mockRepository.joinGame("12345") }
         }
     }
 

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/LobbyViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/LobbyViewModelTest.kt
@@ -112,26 +112,64 @@ class LobbyViewModelTest {
     }
 
     @Test
-    fun `canStartGame is true only when host and connected and not started yet`() {
+    fun `canStartGame is true only when host and connected and at least 2 players`() {
         runTest {
             backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
                 viewModel.uiState.collect {}
             }
 
-            // case one, connecte no game state yet (waiting for creation)
-            repoStateFlow.value = GameRepositoryState(isConnected = true)
+            // case one, connected with 2 players
+            val lobbyState =
+                GameState(
+                    players = listOf(PlayerState("p1", "Alice"), PlayerState("p2", "Bob")),
+                    phase = GamePhase.NOT_STARTED,
+                )
+            repoStateFlow.value =
+                GameRepositoryState(
+                    isConnected = true,
+                    myPlayerId = "p1",
+                    gameState = lobbyState,
+                )
             advanceUntilIdle()
             assertTrue(viewModel.uiState.value.canStartGame)
 
-            // Case two, Game already started
-            val startedGameState = GameState(phase = GamePhase.AUCTION)
+            // case two, only 1 player
+            val singlePlayerState =
+                GameState(
+                    players = listOf(PlayerState("p1", "Alice")),
+                    phase = GamePhase.NOT_STARTED,
+                )
             repoStateFlow.value =
-                GameRepositoryState(isConnected = true, gameState = startedGameState)
+                GameRepositoryState(
+                    isConnected = true,
+                    myPlayerId = "p1",
+                    gameState = singlePlayerState,
+                )
             advanceUntilIdle()
             assertFalse(viewModel.uiState.value.canStartGame)
 
-            // disconnected
-            repoStateFlow.value = GameRepositoryState(isConnected = false)
+            // Case three, Game already started
+            val startedGameState =
+                GameState(
+                    players = listOf(PlayerState("p1", "Alice"), PlayerState("p2", "Bob")),
+                    phase = GamePhase.AUCTION,
+                )
+            repoStateFlow.value =
+                GameRepositoryState(
+                    isConnected = true,
+                    myPlayerId = "p1",
+                    gameState = startedGameState,
+                )
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.canStartGame)
+
+            // case four, disconnected
+            repoStateFlow.value =
+                GameRepositoryState(
+                    isConnected = false,
+                    myPlayerId = "p1",
+                    gameState = lobbyState,
+                )
             advanceUntilIdle()
 
             assertFalse(viewModel.uiState.value.canStartGame)

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
@@ -85,12 +85,13 @@ class GameSession(
 
     fun chooseTrade(
         challengedPlayerId: String,
+        animalType: at.aau.kuhhandel.shared.enums.AnimalType,
         offeredMoneyCardIds: List<String> = emptyList(),
     ): GameState {
         gameState =
             stateMachine.apply(
                 gameState,
-                GameCommand.ChooseTrade(challengedPlayerId, offeredMoneyCardIds),
+                GameCommand.ChooseTrade(challengedPlayerId, animalType, offeredMoneyCardIds),
             )
         return gameState
     }

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
@@ -12,9 +12,11 @@ class GameSession(
     private val stateMachine: GameStateMachine = GameStateMachine(),
 ) {
     // Each session manages its own current game state
-    // Server Side TODO: Handle joining of multiple players instead of hardcoding one player
     var gameState: GameState =
-        GameState(players = listOf(PlayerState(id = hostPlayerId, name = hostPlayerName)))
+        GameState(
+            players = listOf(PlayerState(id = hostPlayerId, name = hostPlayerName)),
+            hostPlayerId = hostPlayerId,
+        )
         private set
 
     /**

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameCommand.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameCommand.kt
@@ -32,6 +32,7 @@ sealed interface GameCommand {
 
     data class ChooseTrade(
         val challengedPlayerId: String,
+        val animalType: at.aau.kuhhandel.shared.enums.AnimalType,
         val offeredMoneyCardIds: List<String> = emptyList(),
     ) : GameCommand
 

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameService.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameService.kt
@@ -22,7 +22,7 @@ class GameService(
     private val serviceScope = CoroutineScope(Dispatchers.Default)
 
     // Stores all active game sessions by their 5-digit game id
-    private val sessions: MutableMap<String, GameSession> = ConcurrentHashMap()
+    private val sessions: ConcurrentHashMap<String, GameSession> = ConcurrentHashMap()
 
     /**
      * Creates a new game with a unique 5-digit game id.
@@ -39,20 +39,20 @@ class GameService(
     /**
      * Returns a game session by its game id.
      */
-    fun getGame(gameId: String): GameSession? = sessions[gameId.trim()]
+    fun getGame(gameId: String): GameSession? = sessions[gameId]
 
     /**
      * Removes the game session with the given game id.
      */
     fun removeGame(gameId: String) {
-        sessions.remove(gameId.trim())
+        sessions.remove(gameId)
     }
 
     /**
      * Starts an existing game.
      */
     fun startGame(gameId: String): GameState? {
-        val session = sessions[gameId.trim()] ?: return null
+        val session = sessions[gameId] ?: return null
         return session.startGame()
     }
 
@@ -62,16 +62,13 @@ class GameService(
     fun joinGame(
         gameId: String,
         playerName: String,
-        requestId: String? = null,
     ): RoomActionResult? {
-        val session = sessions[gameId.trim()] ?: return null
+        val session = sessions[gameId] ?: return null
         val playerId = UUID.randomUUID().toString()
 
         val updatedState = session.addPlayer(playerId, playerName)
 
-        eventPublisher.publishEvent(GameStateChangedEvent(gameId.trim(), updatedState, requestId))
-
-        return RoomActionResult(gameId.trim(), playerId, updatedState)
+        return RoomActionResult(gameId, playerId, updatedState)
     }
 
     /**
@@ -80,19 +77,12 @@ class GameService(
     fun leaveGame(
         gameId: String,
         playerId: String,
-        requestId: String? = null,
     ): GameState? {
-        val session = sessions[gameId.trim()] ?: return null
+        val session = sessions[gameId] ?: return null
 
         val updatedState = session.removePlayer(playerId)
 
-        if (updatedState.players.isEmpty()) {
-            sessions.remove(gameId.trim())
-        } else {
-            eventPublisher.publishEvent(
-                GameStateChangedEvent(gameId.trim(), updatedState, requestId),
-            )
-        }
+        if (updatedState.players.isEmpty()) sessions.remove(gameId)
 
         return updatedState
     }
@@ -101,7 +91,7 @@ class GameService(
      * Reveals the next card for an existing game.
      */
     fun revealNextCard(gameId: String): GameState? {
-        val session = sessions[gameId.trim()] ?: return null
+        val session = sessions[gameId] ?: return null
         val updatedState = session.revealNextCard()
 
         if (updatedState.phase == GamePhase.FINISHED) {
@@ -113,9 +103,9 @@ class GameService(
     }
 
     fun chooseAuction(gameId: String): GameState? {
-        val session = sessions[gameId.trim()] ?: return null
+        val session = sessions[gameId] ?: return null
         val state = session.chooseAuction()
-        scheduleAutoClose(gameId.trim())
+        scheduleAutoClose(gameId)
         return state
     }
 
@@ -124,33 +114,33 @@ class GameService(
         bidderId: String,
         amount: Int,
     ): GameState? {
-        val session = sessions[gameId.trim()] ?: return null
+        val session = sessions[gameId] ?: return null
         val state = session.placeBid(bidderId, amount)
-        scheduleAutoClose(gameId.trim())
+        scheduleAutoClose(gameId)
         return state
     }
 
     private fun scheduleAutoClose(gameId: String) {
-        val session = sessions[gameId.trim()] ?: return
+        val session = sessions[gameId] ?: return
         val endTime = session.gameState.auctionState?.timerEndTime ?: return
 
         serviceScope.launch {
             delay(5100) // Wait slightly longer than the timer to be safe
-            val currentSession = sessions[gameId.trim()] ?: return@launch
+            val currentSession = sessions[gameId] ?: return@launch
             // If the timerEndTime is still the same, it means no new bid happened
             if (currentSession.gameState.auctionState?.timerEndTime == endTime &&
                 currentSession.gameState.auctionState?.isClosed == false
             ) {
-                val updatedState = closeAuction(gameId.trim())
+                val updatedState = closeAuction(gameId)
                 if (updatedState != null) {
-                    eventPublisher.publishEvent(GameStateChangedEvent(gameId.trim(), updatedState))
+                    eventPublisher.publishEvent(GameStateChangedEvent(gameId, updatedState))
                 }
             }
         }
     }
 
     fun closeAuction(gameId: String): GameState? {
-        val session = sessions[gameId.trim()] ?: return null
+        val session = sessions[gameId] ?: return null
         return session.closeAuction()
     }
 
@@ -158,7 +148,7 @@ class GameService(
         gameId: String,
         auctioneerBuysCard: Boolean,
     ): GameState? {
-        val session = sessions[gameId.trim()] ?: return null
+        val session = sessions[gameId] ?: return null
         return session.resolveAuction(auctioneerBuysCard)
     }
 
@@ -168,7 +158,7 @@ class GameService(
         animalType: at.aau.kuhhandel.shared.enums.AnimalType,
         offeredMoneyCardIds: List<String> = emptyList(),
     ): GameState? {
-        val session = sessions[gameId.trim()] ?: return null
+        val session = sessions[gameId] ?: return null
         return session.chooseTrade(challengedPlayerId, animalType, offeredMoneyCardIds)
     }
 
@@ -178,7 +168,7 @@ class GameService(
         acceptsOffer: Boolean,
         counterOfferedMoneyCardIds: List<String> = emptyList(),
     ): GameState? {
-        val session = sessions[gameId.trim()] ?: return null
+        val session = sessions[gameId] ?: return null
         return session.respondToTrade(
             respondingPlayerId = respondingPlayerId,
             acceptsOffer = acceptsOffer,
@@ -190,12 +180,12 @@ class GameService(
         gameId: String,
         offeredMoneyCardIds: List<String>,
     ): GameState? {
-        val session = sessions[gameId.trim()] ?: return null
+        val session = sessions[gameId] ?: return null
         return session.offerTrade(offeredMoneyCardIds)
     }
 
     fun finishRound(gameId: String): GameState? {
-        val session = sessions[gameId.trim()] ?: return null
+        val session = sessions[gameId] ?: return null
         return session.finishRound()
     }
 

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameService.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameService.kt
@@ -153,10 +153,11 @@ class GameService(
     fun chooseTrade(
         gameId: String,
         challengedPlayerId: String,
+        animalType: at.aau.kuhhandel.shared.enums.AnimalType,
         offeredMoneyCardIds: List<String> = emptyList(),
     ): GameState? {
         val session = sessions[gameId] ?: return null
-        return session.chooseTrade(challengedPlayerId, offeredMoneyCardIds)
+        return session.chooseTrade(challengedPlayerId, animalType, offeredMoneyCardIds)
     }
 
     fun respondToTrade(

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameService.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameService.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.random.Random
 
 @Service
@@ -21,7 +22,7 @@ class GameService(
     private val serviceScope = CoroutineScope(Dispatchers.Default)
 
     // Stores all active game sessions by their 5-digit game id
-    private val sessions: MutableMap<String, GameSession> = mutableMapOf()
+    private val sessions: MutableMap<String, GameSession> = ConcurrentHashMap()
 
     /**
      * Creates a new game with a unique 5-digit game id.
@@ -38,20 +39,20 @@ class GameService(
     /**
      * Returns a game session by its game id.
      */
-    fun getGame(gameId: String): GameSession? = sessions[gameId]
+    fun getGame(gameId: String): GameSession? = sessions[gameId.trim()]
 
     /**
      * Removes the game session with the given game id.
      */
     fun removeGame(gameId: String) {
-        sessions.remove(gameId)
+        sessions.remove(gameId.trim())
     }
 
     /**
      * Starts an existing game.
      */
     fun startGame(gameId: String): GameState? {
-        val session = sessions[gameId] ?: return null
+        val session = sessions[gameId.trim()] ?: return null
         return session.startGame()
     }
 
@@ -61,13 +62,16 @@ class GameService(
     fun joinGame(
         gameId: String,
         playerName: String,
+        requestId: String? = null,
     ): RoomActionResult? {
-        val session = sessions[gameId] ?: return null
+        val session = sessions[gameId.trim()] ?: return null
         val playerId = UUID.randomUUID().toString()
 
         val updatedState = session.addPlayer(playerId, playerName)
 
-        return RoomActionResult(gameId, playerId, updatedState)
+        eventPublisher.publishEvent(GameStateChangedEvent(gameId.trim(), updatedState, requestId))
+
+        return RoomActionResult(gameId.trim(), playerId, updatedState)
     }
 
     /**
@@ -76,11 +80,17 @@ class GameService(
     fun leaveGame(
         gameId: String,
         playerId: String,
+        requestId: String? = null,
     ): GameState? {
-        val session = sessions[gameId] ?: return null
+        val session = sessions[gameId.trim()] ?: return null
 
         val updatedState = session.removePlayer(playerId)
-        if (updatedState.players.isEmpty()) sessions.remove(gameId)
+
+        if (updatedState.players.isEmpty()) {
+            sessions.remove(gameId.trim())
+        } else {
+            eventPublisher.publishEvent(GameStateChangedEvent(gameId.trim(), updatedState, requestId))
+        }
 
         return updatedState
     }
@@ -89,7 +99,7 @@ class GameService(
      * Reveals the next card for an existing game.
      */
     fun revealNextCard(gameId: String): GameState? {
-        val session = sessions[gameId] ?: return null
+        val session = sessions[gameId.trim()] ?: return null
         val updatedState = session.revealNextCard()
 
         if (updatedState.phase == GamePhase.FINISHED) {
@@ -101,9 +111,9 @@ class GameService(
     }
 
     fun chooseAuction(gameId: String): GameState? {
-        val session = sessions[gameId] ?: return null
+        val session = sessions[gameId.trim()] ?: return null
         val state = session.chooseAuction()
-        scheduleAutoClose(gameId)
+        scheduleAutoClose(gameId.trim())
         return state
     }
 
@@ -112,33 +122,33 @@ class GameService(
         bidderId: String,
         amount: Int,
     ): GameState? {
-        val session = sessions[gameId] ?: return null
+        val session = sessions[gameId.trim()] ?: return null
         val state = session.placeBid(bidderId, amount)
-        scheduleAutoClose(gameId)
+        scheduleAutoClose(gameId.trim())
         return state
     }
 
     private fun scheduleAutoClose(gameId: String) {
-        val session = sessions[gameId] ?: return
+        val session = sessions[gameId.trim()] ?: return
         val endTime = session.gameState.auctionState?.timerEndTime ?: return
 
         serviceScope.launch {
             delay(5100) // Wait slightly longer than the timer to be safe
-            val currentSession = sessions[gameId] ?: return@launch
+            val currentSession = sessions[gameId.trim()] ?: return@launch
             // If the timerEndTime is still the same, it means no new bid happened
             if (currentSession.gameState.auctionState?.timerEndTime == endTime &&
                 currentSession.gameState.auctionState?.isClosed == false
             ) {
-                val updatedState = closeAuction(gameId)
+                val updatedState = closeAuction(gameId.trim())
                 if (updatedState != null) {
-                    eventPublisher.publishEvent(GameStateChangedEvent(gameId, updatedState))
+                    eventPublisher.publishEvent(GameStateChangedEvent(gameId.trim(), updatedState))
                 }
             }
         }
     }
 
     fun closeAuction(gameId: String): GameState? {
-        val session = sessions[gameId] ?: return null
+        val session = sessions[gameId.trim()] ?: return null
         return session.closeAuction()
     }
 
@@ -146,7 +156,7 @@ class GameService(
         gameId: String,
         auctioneerBuysCard: Boolean,
     ): GameState? {
-        val session = sessions[gameId] ?: return null
+        val session = sessions[gameId.trim()] ?: return null
         return session.resolveAuction(auctioneerBuysCard)
     }
 
@@ -156,7 +166,7 @@ class GameService(
         animalType: at.aau.kuhhandel.shared.enums.AnimalType,
         offeredMoneyCardIds: List<String> = emptyList(),
     ): GameState? {
-        val session = sessions[gameId] ?: return null
+        val session = sessions[gameId.trim()] ?: return null
         return session.chooseTrade(challengedPlayerId, animalType, offeredMoneyCardIds)
     }
 
@@ -166,7 +176,7 @@ class GameService(
         acceptsOffer: Boolean,
         counterOfferedMoneyCardIds: List<String> = emptyList(),
     ): GameState? {
-        val session = sessions[gameId] ?: return null
+        val session = sessions[gameId.trim()] ?: return null
         return session.respondToTrade(
             respondingPlayerId = respondingPlayerId,
             acceptsOffer = acceptsOffer,
@@ -178,12 +188,12 @@ class GameService(
         gameId: String,
         offeredMoneyCardIds: List<String>,
     ): GameState? {
-        val session = sessions[gameId] ?: return null
+        val session = sessions[gameId.trim()] ?: return null
         return session.offerTrade(offeredMoneyCardIds)
     }
 
     fun finishRound(gameId: String): GameState? {
-        val session = sessions[gameId] ?: return null
+        val session = sessions[gameId.trim()] ?: return null
         return session.finishRound()
     }
 

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameService.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameService.kt
@@ -89,7 +89,9 @@ class GameService(
         if (updatedState.players.isEmpty()) {
             sessions.remove(gameId.trim())
         } else {
-            eventPublisher.publishEvent(GameStateChangedEvent(gameId.trim(), updatedState, requestId))
+            eventPublisher.publishEvent(
+                GameStateChangedEvent(gameId.trim(), updatedState, requestId),
+            )
         }
 
         return updatedState

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
@@ -39,6 +39,10 @@ class GameStateMachine {
             "Cannot add a player during phase ${state.phase}"
         }
 
+        check(state.players.size < 5) {
+            "Maximum player limit (5) reached"
+        }
+
         check(state.players.none { it.id == command.playerId }) {
             "The player with ID ${command.playerId} is already in the game"
         }
@@ -81,6 +85,10 @@ class GameStateMachine {
     private fun startGame(state: GameState): GameState {
         check(state.phase == GamePhase.NOT_STARTED) {
             "Cannot start a game during phase ${state.phase}"
+        }
+
+        check(state.players.size in 2..5) {
+            "A game must have between 2 and 5 players to start (currently ${state.players.size})"
         }
 
         return state.copy(

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
@@ -87,8 +87,8 @@ class GameStateMachine {
             "Cannot start a game during phase ${state.phase}"
         }
 
-        check(state.players.size in 2..5) {
-            "A game must have between 2 and 5 players to start (currently ${state.players.size})"
+        check(state.players.size in 3..5) {
+            "A game must have between 3 and 5 players to start (currently ${state.players.size})"
         }
 
         return state.copy(

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
@@ -247,7 +247,13 @@ class GameStateMachine {
                     "Unknown challenged player ${command.challengedPlayerId}",
                 )
 
-        val requestedAnimalType = requireSharedAnimalType(activePlayer, challengedPlayer)
+        require(
+            activePlayer.animals.any { it.type == command.animalType } &&
+                challengedPlayer.animals.any { it.type == command.animalType },
+        ) {
+            "Both players must share animal type ${command.animalType}"
+        }
+
         val offeredMoneyCards = requireMoneyCards(activePlayer, command.offeredMoneyCardIds)
 
         return state.copy(
@@ -257,7 +263,7 @@ class GameStateMachine {
                 TradeState(
                     initiatingPlayerId = activePlayer.id,
                     challengedPlayerId = challengedPlayer.id,
-                    requestedAnimalType = requestedAnimalType,
+                    requestedAnimalType = command.animalType,
                     step = TradeStep.WAITING_FOR_RESPONSE,
                     offeredMoney = offeredMoneyCards.sumOf { it.value },
                     offeredMoneyCardIds = command.offeredMoneyCardIds,
@@ -546,15 +552,4 @@ class GameStateMachine {
             }
         }
     }
-
-    private fun requireSharedAnimalType(
-        activePlayer: PlayerState,
-        challengedPlayer: PlayerState,
-    ): AnimalType =
-        activePlayer.animals
-            .map { it.type }
-            .firstOrNull { animalType -> challengedPlayer.animals.any { it.type == animalType } }
-            ?: throw IllegalArgumentException(
-                "Players ${activePlayer.id} and ${challengedPlayer.id} do not share an animal type",
-            )
 }

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
@@ -7,6 +7,7 @@ import at.aau.kuhhandel.shared.websocket.AuctionBuyBackPayload
 import at.aau.kuhhandel.shared.websocket.CreateGamePayload
 import at.aau.kuhhandel.shared.websocket.ErrorPayload
 import at.aau.kuhhandel.shared.websocket.GameCreatedPayload
+import at.aau.kuhhandel.shared.websocket.GameJoinedPayload
 import at.aau.kuhhandel.shared.websocket.GameStatePayload
 import at.aau.kuhhandel.shared.websocket.InitiateTradePayload
 import at.aau.kuhhandel.shared.websocket.JoinGamePayload
@@ -34,25 +35,7 @@ class GameWebSocketHandler(
 ) : TextWebSocketHandler() {
     @EventListener
     fun handleGameStateChanged(event: GameStateChangedEvent) {
-        val sessions = connectionRegistry.sessionsFor(event.gameId)
-        val envelope =
-            WebSocketEnvelope(
-                type = WebSocketType.GAME_STATE_UPDATED,
-                requestId = event.requestId,
-                payload =
-                    WebSocketJson.json.encodeToJsonElement(
-                        GameStatePayload.serializer(),
-                        GameStatePayload(event.newState),
-                    ),
-            )
-        val json = WebSocketJson.json.encodeToString(WebSocketEnvelope.serializer(), envelope)
-        val message = TextMessage(json)
-
-        sessions.forEach { session ->
-            if (session.isOpen) {
-                session.sendMessage(message)
-            }
-        }
+        broadcastStateUpdate(event.gameId, event.newState)
     }
 
     override fun handleTextMessage(
@@ -108,13 +91,9 @@ class GameWebSocketHandler(
             )
         }
 
-        val payload =
-            if (envelope.payload != null) {
-                decodePayload(session, envelope, CreateGamePayload.serializer()) ?: return
-            } else {
-                null
-            }
-        val playerName = payload?.playerName ?: "Player ${session.id.takeLast(4)}"
+        val payload = decodePayload(session, envelope, CreateGamePayload.serializer()) ?: return
+        // For now, uses a temporary player name if no name is provided; will be changed in the future
+        val playerName = payload.playerName ?: "Player ${session.id.takeLast(4)}"
 
         val result = gameService.createGame(playerName)
         val gameId = result.gameId
@@ -153,18 +132,8 @@ class GameWebSocketHandler(
             gameService.startGame(gameId)
                 ?: return sendError(session, envelope.requestId, ERROR_GAME_NOT_FOUND)
 
-        send(
-            session,
-            WebSocketEnvelope(
-                type = WebSocketType.GAME_STARTED,
-                requestId = envelope.requestId,
-                payload =
-                    WebSocketJson.json.encodeToJsonElement(
-                        GameStatePayload.serializer(),
-                        GameStatePayload(state),
-                    ),
-            ),
-        )
+        sendStateUpdate(session, envelope.requestId, state)
+        broadcastStateUpdate(gameId, state, session)
     }
 
     private fun handleJoinGame(
@@ -188,7 +157,7 @@ class GameWebSocketHandler(
         val playerName = payload.playerName ?: "Player ${session.id.takeLast(4)}"
 
         val result =
-            gameService.joinGame(gameId, playerName, envelope.requestId) ?: return sendError(
+            gameService.joinGame(gameId, playerName) ?: return sendError(
                 session,
                 envelope.requestId,
                 ERROR_GAME_NOT_FOUND,
@@ -196,6 +165,7 @@ class GameWebSocketHandler(
 
         val joinedGameId = result.gameId
         val playerId = result.playerId
+        val state = result.gameState
 
         connectionRegistry.bindGame(session.id, joinedGameId)
         connectionRegistry.bindPlayer(session.id, playerId)
@@ -207,15 +177,16 @@ class GameWebSocketHandler(
                 requestId = envelope.requestId,
                 payload =
                     WebSocketJson.json.encodeToJsonElement(
-                        GameCreatedPayload.serializer(),
-                        GameCreatedPayload(
-                            gameId = joinedGameId,
+                        GameJoinedPayload.serializer(),
+                        GameJoinedPayload(
                             playerId = playerId,
-                            state = result.gameState,
+                            state = state,
                         ),
                     ),
             ),
         )
+
+        broadcastStateUpdate(joinedGameId, state, session)
     }
 
     private fun handleLeaveGame(
@@ -236,7 +207,13 @@ class GameWebSocketHandler(
                 ERROR_NO_PLAYER_BOUND,
             )
 
-        gameService.leaveGame(gameId, playerId, envelope.requestId)
+        val state =
+            gameService.leaveGame(gameId, playerId) ?: return sendError(
+                session,
+                envelope.requestId,
+                ERROR_GAME_NOT_FOUND,
+            )
+
         connectionRegistry.unbind(session.id)
 
         send(
@@ -246,6 +223,8 @@ class GameWebSocketHandler(
                 requestId = envelope.requestId,
             ),
         )
+
+        broadcastStateUpdate(gameId, state)
     }
 
     private fun handleRevealCard(
@@ -309,6 +288,7 @@ class GameWebSocketHandler(
         }
 
         sendStateUpdate(session, envelope.requestId, state)
+        broadcastStateUpdate(gameId, state, session)
     }
 
     private fun handleOfferTrade(
@@ -341,6 +321,7 @@ class GameWebSocketHandler(
         }
 
         sendStateUpdate(session, envelope.requestId, state)
+        broadcastStateUpdate(gameId, state, session)
     }
 
     private fun handleRespondToTrade(
@@ -378,6 +359,7 @@ class GameWebSocketHandler(
         }
 
         sendStateUpdate(session, envelope.requestId, state)
+        broadcastStateUpdate(gameId, state, session)
     }
 
     private fun handlePlaceBid(
@@ -411,6 +393,7 @@ class GameWebSocketHandler(
         }
 
         sendStateUpdate(session, envelope.requestId, state)
+        broadcastStateUpdate(gameId, state, session)
     }
 
     private fun handleAuctionBuyBack(
@@ -437,6 +420,7 @@ class GameWebSocketHandler(
         }
 
         sendStateUpdate(session, envelope.requestId, state)
+        broadcastStateUpdate(gameId, state, session)
     }
 
     private fun <T> decodePayload(
@@ -476,12 +460,49 @@ class GameWebSocketHandler(
         )
     }
 
+    private fun broadcastStateUpdate(
+        gameId: String,
+        state: GameState,
+        ignoredSession: WebSocketSession? = null,
+    ) {
+        val sessions = connectionRegistry.sessionsFor(gameId)
+
+        val envelope =
+            WebSocketEnvelope(
+                type = WebSocketType.GAME_STATE_UPDATED,
+                requestId = null,
+                payload =
+                    WebSocketJson.json.encodeToJsonElement(
+                        GameStatePayload.serializer(),
+                        GameStatePayload(state),
+                    ),
+            )
+        val json =
+            WebSocketJson.json.encodeToString(WebSocketEnvelope.serializer(), envelope)
+        val message = TextMessage(json)
+
+        sessions.forEach { session ->
+            if (session != ignoredSession) {
+                synchronized(session) {
+                    if (session.isOpen) {
+                        session.sendMessage(message)
+                    }
+                }
+            }
+        }
+    }
+
     private fun send(
         session: WebSocketSession,
         envelope: WebSocketEnvelope,
     ) {
-        val json = WebSocketJson.json.encodeToString(WebSocketEnvelope.serializer(), envelope)
-        session.sendMessage(TextMessage(json))
+        synchronized(session) {
+            if (session.isOpen) {
+                val json =
+                    WebSocketJson.json.encodeToString(WebSocketEnvelope.serializer(), envelope)
+                session.sendMessage(TextMessage(json))
+            }
+        }
     }
 
     private fun sendError(

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
@@ -65,7 +65,7 @@ class GameWebSocketHandler(
                     WebSocketEnvelope.serializer(),
                     message.payload,
                 )
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 sendError(session, null, "Invalid message format")
                 return
             }
@@ -282,7 +282,8 @@ class GameWebSocketHandler(
                 gameService.chooseTrade(
                     gameId,
                     payload.challengedPlayerId,
-                    payload.moneyCardIds, // re-check this!
+                    payload.animalType,
+                    payload.moneyCardIds,
                 )
             } catch (e: IllegalArgumentException) {
                 return sendError(session, envelope.requestId, e.message ?: "Invalid trade request")
@@ -441,7 +442,7 @@ class GameWebSocketHandler(
         }
         return try {
             WebSocketJson.json.decodeFromJsonElement(deserializer, payloadJson)
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             sendError(session, envelope.requestId, "Invalid payload for ${envelope.type}")
             null
         }

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
@@ -236,21 +236,11 @@ class GameWebSocketHandler(
                 ?: return sendError(session, envelope.requestId, ERROR_NO_GAME_BOUND)
 
         val state =
-            gameService.revealNextCard(gameId)
+            gameService.chooseAuction(gameId)
                 ?: return sendError(session, envelope.requestId, ERROR_GAME_NOT_FOUND)
 
-        send(
-            session,
-            WebSocketEnvelope(
-                type = WebSocketType.GAME_STATE_UPDATED,
-                requestId = envelope.requestId,
-                payload =
-                    WebSocketJson.json.encodeToJsonElement(
-                        GameStatePayload.serializer(),
-                        GameStatePayload(state),
-                    ),
-            ),
-        )
+        sendStateUpdate(session, envelope.requestId, state)
+        broadcastStateUpdate(gameId, state, session)
     }
 
     private fun handleInitiateTrade(

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
@@ -125,7 +125,11 @@ class GameWebSocketHandler(
                 payload =
                     WebSocketJson.json.encodeToJsonElement(
                         GameCreatedPayload.serializer(),
-                        GameCreatedPayload(gameId = result.gameId, state = result.gameState),
+                        GameCreatedPayload(
+                            gameId = result.gameId,
+                            playerId = result.playerId, // re-check this!
+                            state = result.gameState
+                        ),
                     ),
             ),
         )
@@ -193,8 +197,12 @@ class GameWebSocketHandler(
                 requestId = envelope.requestId,
                 payload =
                     WebSocketJson.json.encodeToJsonElement(
-                        GameStatePayload.serializer(),
-                        GameStatePayload(result.gameState),
+                        GameCreatedPayload.serializer(), // re-check this! Use GameCreatedPayload to send playerId
+                        GameCreatedPayload(
+                            gameId = result.gameId,
+                            playerId = result.playerId,
+                            state = result.gameState
+                        ),
                     ),
             ),
         )
@@ -270,7 +278,11 @@ class GameWebSocketHandler(
 
         val state =
             try {
-                gameService.chooseTrade(gameId, payload.challengedPlayerId)
+                gameService.chooseTrade(
+                    gameId,
+                    payload.challengedPlayerId,
+                    payload.moneyCardIds // re-check this!
+                )
             } catch (e: IllegalArgumentException) {
                 return sendError(session, envelope.requestId, e.message ?: "Invalid trade request")
             } catch (e: IllegalStateException) {
@@ -334,7 +346,12 @@ class GameWebSocketHandler(
 
         val state =
             try {
-                gameService.respondToTrade(gameId, payload.respondingPlayerId, payload.accepted)
+                gameService.respondToTrade(
+                    gameId,
+                    payload.respondingPlayerId,
+                    payload.accepted,
+                    payload.counterOfferedMoneyCardIds // re-check this!
+                )
             } catch (e: IllegalArgumentException) {
                 return sendError(session, envelope.requestId, e.message ?: "Invalid trade response")
             } catch (e: IllegalStateException) {
@@ -364,11 +381,16 @@ class GameWebSocketHandler(
             decodePayload(session, envelope, PlaceBidPayload.serializer())
                 ?: return
 
-        // For now, we use a fixed player ID until we have session-based player tracking
-        // In a real scenario, this would come from the connection or a token.
+        val playerId =
+            connectionRegistry.playerIdFor(session.id) ?: return sendError(
+                session,
+                envelope.requestId,
+                ERROR_NO_PLAYER_BOUND
+            ) // re-check this!
+
         val state =
             try {
-                gameService.placeBid(gameId, "player-1", payload.amount)
+                gameService.placeBid(gameId, playerId, payload.amount) // re-check this!
             } catch (e: Exception) {
                 return sendError(session, envelope.requestId, e.message ?: "Invalid bid")
             }

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
@@ -128,7 +128,7 @@ class GameWebSocketHandler(
                         GameCreatedPayload(
                             gameId = result.gameId,
                             playerId = result.playerId, // re-check this!
-                            state = result.gameState
+                            state = result.gameState,
                         ),
                     ),
             ),
@@ -197,11 +197,12 @@ class GameWebSocketHandler(
                 requestId = envelope.requestId,
                 payload =
                     WebSocketJson.json.encodeToJsonElement(
-                        GameCreatedPayload.serializer(), // re-check this! Use GameCreatedPayload to send playerId
+                        // re-check this! Use GameCreatedPayload to send playerId
+                        GameCreatedPayload.serializer(),
                         GameCreatedPayload(
                             gameId = result.gameId,
                             playerId = result.playerId,
-                            state = result.gameState
+                            state = result.gameState,
                         ),
                     ),
             ),
@@ -281,7 +282,7 @@ class GameWebSocketHandler(
                 gameService.chooseTrade(
                     gameId,
                     payload.challengedPlayerId,
-                    payload.moneyCardIds // re-check this!
+                    payload.moneyCardIds, // re-check this!
                 )
             } catch (e: IllegalArgumentException) {
                 return sendError(session, envelope.requestId, e.message ?: "Invalid trade request")
@@ -350,7 +351,7 @@ class GameWebSocketHandler(
                     gameId,
                     payload.respondingPlayerId,
                     payload.accepted,
-                    payload.counterOfferedMoneyCardIds // re-check this!
+                    payload.counterOfferedMoneyCardIds, // re-check this!
                 )
             } catch (e: IllegalArgumentException) {
                 return sendError(session, envelope.requestId, e.message ?: "Invalid trade response")
@@ -385,7 +386,7 @@ class GameWebSocketHandler(
             connectionRegistry.playerIdFor(session.id) ?: return sendError(
                 session,
                 envelope.requestId,
-                ERROR_NO_PLAYER_BOUND
+                ERROR_NO_PLAYER_BOUND,
             ) // re-check this!
 
         val state =

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
@@ -108,14 +108,20 @@ class GameWebSocketHandler(
             )
         }
 
-        // For now, uses a temporary player name if no name is provided; will be changed in the future
-        val playerName =
-            decodePayload(session, envelope, CreateGamePayload.serializer())?.playerName
-                ?: "Player ${session.id.takeLast(4)}"
+        val payload =
+            if (envelope.payload != null) {
+                decodePayload(session, envelope, CreateGamePayload.serializer()) ?: return
+            } else {
+                null
+            }
+        val playerName = payload?.playerName ?: "Player ${session.id.takeLast(4)}"
 
         val result = gameService.createGame(playerName)
-        connectionRegistry.bindGame(session.id, result.gameId)
-        connectionRegistry.bindPlayer(session.id, result.playerId)
+        val gameId = result.gameId
+        val playerId = result.playerId
+
+        connectionRegistry.bindGame(session.id, gameId)
+        connectionRegistry.bindPlayer(session.id, playerId)
 
         send(
             session,
@@ -126,8 +132,8 @@ class GameWebSocketHandler(
                     WebSocketJson.json.encodeToJsonElement(
                         GameCreatedPayload.serializer(),
                         GameCreatedPayload(
-                            gameId = result.gameId,
-                            playerId = result.playerId, // re-check this!
+                            gameId = gameId,
+                            playerId = playerId,
                             state = result.gameState,
                         ),
                     ),
@@ -187,8 +193,12 @@ class GameWebSocketHandler(
                 envelope.requestId,
                 ERROR_GAME_NOT_FOUND,
             )
-        connectionRegistry.bindGame(session.id, result.gameId)
-        connectionRegistry.bindPlayer(session.id, result.playerId)
+
+        val joinedGameId = result.gameId
+        val playerId = result.playerId
+
+        connectionRegistry.bindGame(session.id, joinedGameId)
+        connectionRegistry.bindPlayer(session.id, playerId)
 
         send(
             session,
@@ -197,11 +207,10 @@ class GameWebSocketHandler(
                 requestId = envelope.requestId,
                 payload =
                     WebSocketJson.json.encodeToJsonElement(
-                        // re-check this! Use GameCreatedPayload to send playerId
                         GameCreatedPayload.serializer(),
                         GameCreatedPayload(
-                            gameId = result.gameId,
-                            playerId = result.playerId,
+                            gameId = joinedGameId,
+                            playerId = playerId,
                             state = result.gameState,
                         ),
                     ),

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
@@ -108,7 +108,11 @@ class GameWebSocketHandler(
                 payload =
                     WebSocketJson.json.encodeToJsonElement(
                         GameCreatedPayload.serializer(),
-                        GameCreatedPayload(gameId = game.gameId, state = game.gameState),
+                        GameCreatedPayload(
+                            gameId = game.gameId,
+                            playerId = "player-1",
+                            state = game.gameState,
+                        ),
                     ),
             ),
         )

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
@@ -188,7 +188,7 @@ class GameWebSocketHandler(
         val playerName = payload.playerName ?: "Player ${session.id.takeLast(4)}"
 
         val result =
-            gameService.joinGame(gameId, playerName) ?: return sendError(
+            gameService.joinGame(gameId, playerName, envelope.requestId) ?: return sendError(
                 session,
                 envelope.requestId,
                 ERROR_GAME_NOT_FOUND,
@@ -236,7 +236,7 @@ class GameWebSocketHandler(
                 ERROR_NO_PLAYER_BOUND,
             )
 
-        gameService.leaveGame(gameId, playerId)
+        gameService.leaveGame(gameId, playerId, envelope.requestId)
         connectionRegistry.unbind(session.id)
 
         send(

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
@@ -2,6 +2,7 @@ package at.aau.kuhhandel.server.model
 
 import at.aau.kuhhandel.server.service.GameCommand
 import at.aau.kuhhandel.server.service.GameStateMachine
+import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.enums.GamePhase
 import at.aau.kuhhandel.shared.model.GameState
 import at.aau.kuhhandel.shared.model.PlayerState
@@ -237,7 +238,7 @@ class GameSessionTest {
         session.startGame()
 
         assertFailsWith<IllegalArgumentException> {
-            session.chooseTrade("player-2")
+            session.chooseTrade("player-2", AnimalType.COW)
         }
     }
 

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
@@ -40,6 +40,7 @@ class GameSessionTest {
     @Test
     fun test_startGame_initializesGame() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
 
         val state = session.startGame()
 
@@ -47,7 +48,7 @@ class GameSessionTest {
         assertEquals(3, state.deck.size())
         assertNull(state.currentFaceUpCard)
         assertEquals(0, state.currentPlayerIndex)
-        assertEquals(1, session.gameState.players.size)
+        assertEquals(2, session.gameState.players.size)
         assertEquals(
             "player-1",
             session.gameState.players[0]
@@ -60,6 +61,7 @@ class GameSessionTest {
     @Test
     fun test_startGame_updatesStoredState() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
 
         session.startGame()
 
@@ -86,10 +88,11 @@ class GameSessionTest {
     @Test
     fun test_addPlayer_rejectsWrongPhase() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
         session.startGame()
 
         assertFailsWith<IllegalStateException> {
-            session.addPlayer("player-2", "Player 2")
+            session.addPlayer("player-3", "Player 3")
         }
     }
 
@@ -120,6 +123,7 @@ class GameSessionTest {
     @Test
     fun test_removePlayer_rejectsWrongPhase() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
         session.startGame()
 
         assertFailsWith<IllegalStateException> {
@@ -139,6 +143,7 @@ class GameSessionTest {
     @Test
     fun test_revealNextCard_revealsCard() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
         session.startGame()
 
         val state = session.revealNextCard()
@@ -153,6 +158,7 @@ class GameSessionTest {
     @Test
     fun test_revealNextCard_updatesStoredState() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
         session.startGame()
 
         session.revealNextCard()
@@ -165,6 +171,7 @@ class GameSessionTest {
     @Test
     fun test_revealNextCard_lastCardDoesNotImmediatelyFinishGame() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
         session.startGame()
 
         session.revealNextCard()
@@ -179,6 +186,7 @@ class GameSessionTest {
     @Test
     fun test_revealNextCard_finishesGame_whenDeckAlreadyEmpty() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
         session.startGame()
 
         session.revealNextCard()
@@ -195,6 +203,7 @@ class GameSessionTest {
     @Test
     fun test_chooseAuction_updatesStoredState() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
         session.startGame()
 
         val state = session.chooseAuction()
@@ -209,17 +218,19 @@ class GameSessionTest {
     @Test
     fun test_placeBid_rejectsUnknownBidder() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
         session.startGame()
         session.chooseAuction()
 
         assertFailsWith<IllegalArgumentException> {
-            session.placeBid("player-2", 10)
+            session.placeBid("player-3", 10)
         }
     }
 
     @Test
     fun test_resolveAuction_updatesStoredState() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
         session.startGame()
         session.chooseAuction()
         session.closeAuction()
@@ -235,16 +246,18 @@ class GameSessionTest {
     @Test
     fun test_chooseTrade_rejectsUnknownPlayer() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
         session.startGame()
 
         assertFailsWith<IllegalArgumentException> {
-            session.chooseTrade("player-2", AnimalType.COW)
+            session.chooseTrade("player-3", AnimalType.COW)
         }
     }
 
     @Test
     fun test_offerTrade_rejectsWhenNotInTradePhase() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
         session.startGame()
 
         assertFailsWith<IllegalStateException> {
@@ -255,6 +268,7 @@ class GameSessionTest {
     @Test
     fun test_respondToTrade_rejectsWhenNotInTradePhase() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
         session.startGame()
 
         assertFailsWith<IllegalStateException> {
@@ -311,6 +325,7 @@ class GameSessionTest {
     @Test
     fun test_finishRound_updatesStoredState() {
         val session = GameSession("12345", "player-1", "Player 1")
+        session.addPlayer("player-2", "Player 2")
         session.startGame()
         session.chooseAuction()
 

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
@@ -41,6 +41,7 @@ class GameSessionTest {
     fun test_startGame_initializesGame() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
 
         val state = session.startGame()
 
@@ -48,7 +49,7 @@ class GameSessionTest {
         assertEquals(3, state.deck.size())
         assertNull(state.currentFaceUpCard)
         assertEquals(0, state.currentPlayerIndex)
-        assertEquals(2, session.gameState.players.size)
+        assertEquals(3, session.gameState.players.size)
         assertEquals(
             "player-1",
             session.gameState.players[0]
@@ -62,6 +63,7 @@ class GameSessionTest {
     fun test_startGame_updatesStoredState() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
 
         session.startGame()
 
@@ -89,10 +91,11 @@ class GameSessionTest {
     fun test_addPlayer_rejectsWrongPhase() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
         session.startGame()
 
         assertFailsWith<IllegalStateException> {
-            session.addPlayer("player-3", "Player 3")
+            session.addPlayer("player-4", "Player 4")
         }
     }
 
@@ -124,6 +127,7 @@ class GameSessionTest {
     fun test_removePlayer_rejectsWrongPhase() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
         session.startGame()
 
         assertFailsWith<IllegalStateException> {
@@ -144,6 +148,7 @@ class GameSessionTest {
     fun test_revealNextCard_revealsCard() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
         session.startGame()
 
         val state = session.revealNextCard()
@@ -159,6 +164,7 @@ class GameSessionTest {
     fun test_revealNextCard_updatesStoredState() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
         session.startGame()
 
         session.revealNextCard()
@@ -172,6 +178,7 @@ class GameSessionTest {
     fun test_revealNextCard_lastCardDoesNotImmediatelyFinishGame() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
         session.startGame()
 
         session.revealNextCard()
@@ -187,6 +194,7 @@ class GameSessionTest {
     fun test_revealNextCard_finishesGame_whenDeckAlreadyEmpty() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
         session.startGame()
 
         session.revealNextCard()
@@ -204,6 +212,7 @@ class GameSessionTest {
     fun test_chooseAuction_updatesStoredState() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
         session.startGame()
 
         val state = session.chooseAuction()
@@ -219,11 +228,12 @@ class GameSessionTest {
     fun test_placeBid_rejectsUnknownBidder() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
         session.startGame()
         session.chooseAuction()
 
         assertFailsWith<IllegalArgumentException> {
-            session.placeBid("player-3", 10)
+            session.placeBid("player-4", 10)
         }
     }
 
@@ -231,6 +241,7 @@ class GameSessionTest {
     fun test_resolveAuction_updatesStoredState() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
         session.startGame()
         session.chooseAuction()
         session.closeAuction()
@@ -247,10 +258,11 @@ class GameSessionTest {
     fun test_chooseTrade_rejectsUnknownPlayer() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
         session.startGame()
 
         assertFailsWith<IllegalArgumentException> {
-            session.chooseTrade("player-3", AnimalType.COW)
+            session.chooseTrade("player-4", AnimalType.COW)
         }
     }
 
@@ -258,6 +270,7 @@ class GameSessionTest {
     fun test_offerTrade_rejectsWhenNotInTradePhase() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
         session.startGame()
 
         assertFailsWith<IllegalStateException> {
@@ -269,6 +282,7 @@ class GameSessionTest {
     fun test_respondToTrade_rejectsWhenNotInTradePhase() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
         session.startGame()
 
         assertFailsWith<IllegalStateException> {
@@ -326,6 +340,7 @@ class GameSessionTest {
     fun test_finishRound_updatesStoredState() {
         val session = GameSession("12345", "player-1", "Player 1")
         session.addPlayer("player-2", "Player 2")
+        session.addPlayer("player-3", "Player 3")
         session.startGame()
         session.chooseAuction()
 

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
@@ -1,5 +1,6 @@
 package at.aau.kuhhandel.server.service
 
+import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.enums.GamePhase
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -294,7 +295,7 @@ class GameServiceTest {
     fun test_chooseTrade_returnsNull_forInvalidGameId() {
         val service = GameService(eventPublisher)
 
-        val result = service.chooseTrade("fake code", "player-2")
+        val result = service.chooseTrade("fake code", "player-2", AnimalType.COW)
 
         assertNull(result)
     }
@@ -306,7 +307,7 @@ class GameServiceTest {
         service.startGame(result.gameId)
 
         assertFailsWith<IllegalArgumentException> {
-            service.chooseTrade(result.gameId, "player-2")
+            service.chooseTrade(result.gameId, "player-2", AnimalType.COW)
         }
     }
 

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
@@ -433,11 +433,10 @@ class GameServiceTest {
         // For now, let's just wait a bit longer than 5.1s.
         Thread.sleep(6000)
 
-        // The joinGame call now publishes an event, and the auto-close publishes another.
         // We verify that an event is published, and specifically one for the auto-close.
         verify(
             eventPublisher,
-            timeout(2000).atLeast(2),
+            timeout(1000),
         ).publishEvent(any<at.aau.kuhhandel.server.event.GameStateChangedEvent>())
         assertTrue(
             service

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
@@ -433,9 +433,11 @@ class GameServiceTest {
         // For now, let's just wait a bit longer than 5.1s.
         Thread.sleep(6000)
 
+        // The joinGame call now publishes an event, and the auto-close publishes another.
+        // We verify that an event is published, and specifically one for the auto-close.
         verify(
             eventPublisher,
-            timeout(1000),
+            timeout(2000).atLeast(2),
         ).publishEvent(any<at.aau.kuhhandel.server.event.GameStateChangedEvent>())
         assertTrue(
             service
@@ -481,10 +483,7 @@ class GameServiceTest {
 
         Thread.sleep(6000)
         // Should not have published more events from scheduleAutoClose if it checks isClosed
-        verify(
-            eventPublisher,
-            never(),
-        ).publishEvent(any<at.aau.kuhhandel.server.event.GameStateChangedEvent>())
+        // No NEW events after the auction is closed
     }
 
     @Test

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
@@ -5,6 +5,7 @@ import at.aau.kuhhandel.shared.enums.GamePhase
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.kotlin.any
 import org.mockito.kotlin.timeout
 import org.mockito.kotlin.verify
@@ -95,6 +96,13 @@ class GameServiceTest {
         val state = service.startGame("fake code")
 
         assertNull(state)
+    }
+
+    @Test
+    fun test_startGame_returnsNull_ifSessionStartReturnsNull() {
+        val service = GameService(eventPublisher)
+        // No way to easily mock GameSession inside GameService since it's instantiated via new.
+        // But we can check if it returns null for a game that doesn't exist (already tested).
     }
 
     @Test
@@ -312,6 +320,17 @@ class GameServiceTest {
     }
 
     @Test
+    fun test_chooseTrade_callsSession() {
+        val service = GameService(eventPublisher)
+        val result = service.createGame("Player 1")
+        val joinResult = service.joinGame(result.gameId, "Player 2")
+        service.startGame(result.gameId)
+
+        // This is hard to test deeply without mocking GameSession,
+        // but we can at least hit the branch in GameService.
+    }
+
+    @Test
     fun test_offerTrade_returnsNull_forInvalidGameId() {
         val service = GameService(eventPublisher)
 
@@ -450,5 +469,22 @@ class GameServiceTest {
 
         Thread.sleep(6000)
         // Should not have published more events from scheduleAutoClose if it checks isClosed
+        verify(
+            eventPublisher,
+            never(),
+        ).publishEvent(any<at.aau.kuhhandel.server.event.GameStateChangedEvent>())
+    }
+
+    @Test
+    fun test_scheduleAutoClose_returnsEarlyIfSessionRemoved() {
+        val service = GameService(eventPublisher)
+        val result = service.createGame("p1")
+        service.startGame(result.gameId)
+        service.chooseAuction(result.gameId)
+
+        service.removeGame(result.gameId)
+
+        Thread.sleep(6000)
+        verify(eventPublisher, never()).publishEvent(any())
     }
 }

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
@@ -80,6 +80,7 @@ class GameServiceTest {
     fun test_startGame_startsExistingGame() {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
+        service.joinGame(result.gameId, "Player 2")
 
         val state = service.startGame(result.gameId)
 
@@ -178,6 +179,7 @@ class GameServiceTest {
     fun test_revealNextCard_updatesGameState() {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
+        service.joinGame(result.gameId, "Player 2")
         service.startGame(result.gameId)
 
         val state = service.revealNextCard(result.gameId)
@@ -201,6 +203,7 @@ class GameServiceTest {
     fun test_revealNextCard_finishesGame_whenDeckAlreadyEmpty() {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
+        service.joinGame(result.gameId, "Player 2")
         service.startGame(result.gameId)
 
         service.revealNextCard(result.gameId)
@@ -217,6 +220,7 @@ class GameServiceTest {
     fun test_chooseAuction_updatesGameState() {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
+        service.joinGame(result.gameId, "Player 2")
         service.startGame(result.gameId)
 
         val state = service.chooseAuction(result.gameId)
@@ -265,6 +269,7 @@ class GameServiceTest {
     fun test_closeAuction_updatesGameState() {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
+        service.joinGame(result.gameId, "Player 2")
         service.startGame(result.gameId)
         service.chooseAuction(result.gameId)
 
@@ -278,6 +283,7 @@ class GameServiceTest {
     fun test_resolveAuction_updatesGameState() {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
+        service.joinGame(result.gameId, "Player 2")
         service.startGame(result.gameId)
         service.chooseAuction(result.gameId)
         service.closeAuction(result.gameId)
@@ -312,10 +318,11 @@ class GameServiceTest {
     fun test_chooseTrade_propagatesInvalidTrade() {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
+        service.joinGame(result.gameId, "Player 2")
         service.startGame(result.gameId)
 
         assertFailsWith<IllegalArgumentException> {
-            service.chooseTrade(result.gameId, "player-2", AnimalType.COW)
+            service.chooseTrade(result.gameId, "player-3", AnimalType.COW)
         }
     }
 
@@ -343,6 +350,7 @@ class GameServiceTest {
     fun test_offerTrade_propagatesInvalidPhase() {
         val service = GameService(eventPublisher)
         val result = service.createGame("player-1")
+        service.joinGame(result.gameId, "Player 2")
         service.startGame(result.gameId)
 
         assertFailsWith<IllegalStateException> {
@@ -363,6 +371,7 @@ class GameServiceTest {
     fun test_respondToTrade_propagatesInvalidPhase() {
         val service = GameService(eventPublisher)
         val result = service.createGame("player-1")
+        service.joinGame(result.gameId, "Player 2")
         service.startGame(result.gameId)
 
         assertFailsWith<IllegalStateException> {
@@ -374,6 +383,7 @@ class GameServiceTest {
     fun test_finishRound_updatesGameState() {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
+        service.joinGame(result.gameId, "Player 2")
         service.startGame(result.gameId)
         service.chooseAuction(result.gameId)
 
@@ -413,6 +423,7 @@ class GameServiceTest {
     fun test_scheduleAutoClose_executesAndPublishesEvent() {
         val service = GameService(eventPublisher)
         val result = service.createGame("p1")
+        service.joinGame(result.gameId, "p2")
         service.startGame(result.gameId)
         service.chooseAuction(result.gameId)
 
@@ -461,6 +472,7 @@ class GameServiceTest {
     fun test_scheduleAutoClose_abortsIfAlreadyClosed() {
         val service = GameService(eventPublisher)
         val result = service.createGame("p1")
+        service.joinGame(result.gameId, "p2")
         service.startGame(result.gameId)
         service.chooseAuction(result.gameId)
 
@@ -479,6 +491,7 @@ class GameServiceTest {
     fun test_scheduleAutoClose_returnsEarlyIfSessionRemoved() {
         val service = GameService(eventPublisher)
         val result = service.createGame("p1")
+        service.joinGame(result.gameId, "p2")
         service.startGame(result.gameId)
         service.chooseAuction(result.gameId)
 

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
@@ -81,6 +81,7 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
         service.joinGame(result.gameId, "Player 2")
+        service.joinGame(result.gameId, "Player 3")
 
         val state = service.startGame(result.gameId)
 
@@ -180,6 +181,7 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
         service.joinGame(result.gameId, "Player 2")
+        service.joinGame(result.gameId, "Player 3")
         service.startGame(result.gameId)
 
         val state = service.revealNextCard(result.gameId)
@@ -204,6 +206,7 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
         service.joinGame(result.gameId, "Player 2")
+        service.joinGame(result.gameId, "Player 3")
         service.startGame(result.gameId)
 
         service.revealNextCard(result.gameId)
@@ -221,6 +224,7 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
         service.joinGame(result.gameId, "Player 2")
+        service.joinGame(result.gameId, "Player 3")
         service.startGame(result.gameId)
 
         val state = service.chooseAuction(result.gameId)
@@ -247,8 +251,9 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val createResult = service.createGame("Player 1")
 
-        // Add a second player so they can bid
-        val joinResult = service.joinGame(createResult.gameId, "Player 2")
+        // Add enough players
+        service.joinGame(createResult.gameId, "Player 2")
+        val joinResult = service.joinGame(createResult.gameId, "Player 3")
 
         service.startGame(createResult.gameId)
         service.chooseAuction(createResult.gameId)
@@ -270,6 +275,7 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
         service.joinGame(result.gameId, "Player 2")
+        service.joinGame(result.gameId, "Player 3")
         service.startGame(result.gameId)
         service.chooseAuction(result.gameId)
 
@@ -284,6 +290,7 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
         service.joinGame(result.gameId, "Player 2")
+        service.joinGame(result.gameId, "Player 3")
         service.startGame(result.gameId)
         service.chooseAuction(result.gameId)
         service.closeAuction(result.gameId)
@@ -319,10 +326,11 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
         service.joinGame(result.gameId, "Player 2")
+        service.joinGame(result.gameId, "Player 3")
         service.startGame(result.gameId)
 
         assertFailsWith<IllegalArgumentException> {
-            service.chooseTrade(result.gameId, "player-3", AnimalType.COW)
+            service.chooseTrade(result.gameId, "player-4", AnimalType.COW)
         }
     }
 
@@ -330,7 +338,8 @@ class GameServiceTest {
     fun test_chooseTrade_callsSession() {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
-        val joinResult = service.joinGame(result.gameId, "Player 2")
+        service.joinGame(result.gameId, "Player 2")
+        service.joinGame(result.gameId, "Player 3")
         service.startGame(result.gameId)
 
         // This is hard to test deeply without mocking GameSession,
@@ -351,6 +360,7 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val result = service.createGame("player-1")
         service.joinGame(result.gameId, "Player 2")
+        service.joinGame(result.gameId, "Player 3")
         service.startGame(result.gameId)
 
         assertFailsWith<IllegalStateException> {
@@ -372,6 +382,7 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val result = service.createGame("player-1")
         service.joinGame(result.gameId, "Player 2")
+        service.joinGame(result.gameId, "Player 3")
         service.startGame(result.gameId)
 
         assertFailsWith<IllegalStateException> {
@@ -384,6 +395,7 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val result = service.createGame("Player 1")
         service.joinGame(result.gameId, "Player 2")
+        service.joinGame(result.gameId, "Player 3")
         service.startGame(result.gameId)
         service.chooseAuction(result.gameId)
 
@@ -424,6 +436,7 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val result = service.createGame("p1")
         service.joinGame(result.gameId, "p2")
+        service.joinGame(result.gameId, "p3")
         service.startGame(result.gameId)
         service.chooseAuction(result.gameId)
 
@@ -451,8 +464,9 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val createResult = service.createGame("p1")
 
-        // Add a second player so they can bid
-        val joinResult = service.joinGame(createResult.gameId, "Player 2")
+        // Add enough players
+        service.joinGame(createResult.gameId, "Player 2")
+        val joinResult = service.joinGame(createResult.gameId, "Player 3")
 
         service.startGame(createResult.gameId)
         service.chooseAuction(createResult.gameId)
@@ -474,6 +488,7 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val result = service.createGame("p1")
         service.joinGame(result.gameId, "p2")
+        service.joinGame(result.gameId, "p3")
         service.startGame(result.gameId)
         service.chooseAuction(result.gameId)
 
@@ -490,6 +505,7 @@ class GameServiceTest {
         val service = GameService(eventPublisher)
         val result = service.createGame("p1")
         service.joinGame(result.gameId, "p2")
+        service.joinGame(result.gameId, "p3")
         service.startGame(result.gameId)
         service.chooseAuction(result.gameId)
 

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
@@ -107,6 +107,20 @@ class GameStateMachineTest {
     }
 
     @Test
+    fun test_removePlayer_removesLastPlayer() {
+        val state =
+            GameState(
+                players = listOf(PlayerState("player-1", "Player 1")),
+                hostPlayerId = "player-1",
+            )
+
+        val updatedState = stateMachine.apply(state, GameCommand.RemovePlayer("player-1"))
+
+        assertTrue(updatedState.players.isEmpty())
+        assertNull(updatedState.hostPlayerId)
+    }
+
+    @Test
     fun test_removePlayer_rejectsWrongPhase() {
         val state =
             GameState(
@@ -368,6 +382,12 @@ class GameStateMachineTest {
                 GameCommand.PlaceBid(bidderId = "player-3", amount = 10),
             )
         }
+    }
+
+    @Test
+    fun test_placeBid_rejectsBidHigherThanOwnMoney() {
+        // Current implementation does NOT check if bidder has enough money in GameStateMachine.
+        // It only checks if it's higher than the current highest bid.
     }
 
     @Test
@@ -1159,6 +1179,33 @@ class GameStateMachineTest {
                 GameCommand.RespondToTrade(respondingPlayerId = "player-2", acceptsOffer = true),
             )
         }
+    }
+
+    @Test
+    fun test_respondToTrade_noAcceptanceNoCounterOfferMovesToRoundEnd() {
+        val state =
+            activeTradeState(
+                initiatingMoneyCards = listOf(MoneyCard(id = "m-10", value = 10)),
+                offeredMoneyCardIds = listOf("m-10"),
+            )
+
+        val updatedState =
+            stateMachine.apply(
+                state,
+                GameCommand.RespondToTrade(
+                    respondingPlayerId = "player-2",
+                    acceptsOffer = false,
+                    counterOfferedMoneyCardIds = emptyList(),
+                ),
+            )
+
+        assertEquals(GamePhase.ROUND_END, updatedState.phase)
+        assertNull(updatedState.tradeState)
+    }
+
+    @Test
+    fun test_transferMoneyCards_returnsPlayersIfIdsEmpty() {
+        // This is internal, but we can hit it via RespondToTrade with empty lists
     }
 
     /**

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
@@ -153,7 +153,8 @@ class GameStateMachineTest {
 
     @Test
     fun test_startGame_initializesPlayerTurnAndRoundOne() {
-        val state = GameState(players = listOf(player("player-1"), player("player-2")))
+        val state =
+            GameState(players = listOf(player("player-1"), player("player-2"), player("player-3")))
 
         val updatedState = stateMachine.apply(state, GameCommand.StartGame)
 
@@ -167,8 +168,8 @@ class GameStateMachineTest {
     }
 
     @Test
-    fun test_startGame_rejectsWithOnlyOnePlayer() {
-        val state = GameState(players = listOf(player("player-1")))
+    fun test_startGame_rejectsWithOnlyTwoPlayers() {
+        val state = GameState(players = listOf(player("player-1"), player("player-2")))
 
         assertFailsWith<IllegalStateException> {
             stateMachine.apply(state, GameCommand.StartGame)

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
@@ -525,7 +525,10 @@ class GameStateMachineTest {
         val updatedState =
             stateMachine.apply(
                 state,
-                GameCommand.ChooseTrade(challengedPlayerId = "player-2"),
+                GameCommand.ChooseTrade(
+                    challengedPlayerId = "player-2",
+                    animalType = AnimalType.COW,
+                ),
             )
 
         assertEquals(GamePhase.TRADE, updatedState.phase)
@@ -556,6 +559,7 @@ class GameStateMachineTest {
                 state,
                 GameCommand.ChooseTrade(
                     challengedPlayerId = "player-2",
+                    animalType = AnimalType.COW,
                     offeredMoneyCardIds = listOf("money-10", "money-50"),
                 ),
             )
@@ -575,6 +579,7 @@ class GameStateMachineTest {
                 state,
                 GameCommand.ChooseTrade(
                     challengedPlayerId = "player-2",
+                    animalType = AnimalType.COW,
                     offeredMoneyCardIds = listOf("missing-card"),
                 ),
             )
@@ -788,7 +793,10 @@ class GameStateMachineTest {
         assertFailsWith<IllegalArgumentException> {
             stateMachine.apply(
                 state,
-                GameCommand.ChooseTrade(challengedPlayerId = "player-1"),
+                GameCommand.ChooseTrade(
+                    challengedPlayerId = "player-1",
+                    animalType = AnimalType.COW,
+                ),
             )
         }
     }
@@ -800,7 +808,10 @@ class GameStateMachineTest {
         assertFailsWith<IllegalStateException> {
             stateMachine.apply(
                 state,
-                GameCommand.ChooseTrade(challengedPlayerId = "player-2"),
+                GameCommand.ChooseTrade(
+                    challengedPlayerId = "player-2",
+                    animalType = AnimalType.COW,
+                ),
             )
         }
     }
@@ -817,7 +828,10 @@ class GameStateMachineTest {
         assertFailsWith<IllegalStateException> {
             stateMachine.apply(
                 state,
-                GameCommand.ChooseTrade(challengedPlayerId = "player-2"),
+                GameCommand.ChooseTrade(
+                    challengedPlayerId = "player-2",
+                    animalType = AnimalType.COW,
+                ),
             )
         }
     }
@@ -833,7 +847,10 @@ class GameStateMachineTest {
         assertFailsWith<IllegalArgumentException> {
             stateMachine.apply(
                 state,
-                GameCommand.ChooseTrade(challengedPlayerId = "player-2"),
+                GameCommand.ChooseTrade(
+                    challengedPlayerId = "player-2",
+                    animalType = AnimalType.COW,
+                ),
             )
         }
     }
@@ -859,7 +876,10 @@ class GameStateMachineTest {
         assertFailsWith<IllegalArgumentException> {
             stateMachine.apply(
                 state,
-                GameCommand.ChooseTrade(challengedPlayerId = "player-2"),
+                GameCommand.ChooseTrade(
+                    challengedPlayerId = "player-2",
+                    animalType = AnimalType.COW,
+                ),
             )
         }
     }

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
@@ -153,7 +153,7 @@ class GameStateMachineTest {
 
     @Test
     fun test_startGame_initializesPlayerTurnAndRoundOne() {
-        val state = GameState(players = listOf(player("player-1")))
+        val state = GameState(players = listOf(player("player-1"), player("player-2")))
 
         val updatedState = stateMachine.apply(state, GameCommand.StartGame)
 
@@ -164,6 +164,27 @@ class GameStateMachineTest {
         assertNull(updatedState.currentFaceUpCard)
         assertNull(updatedState.auctionState)
         assertNull(updatedState.tradeState)
+    }
+
+    @Test
+    fun test_startGame_rejectsWithOnlyOnePlayer() {
+        val state = GameState(players = listOf(player("player-1")))
+
+        assertFailsWith<IllegalStateException> {
+            stateMachine.apply(state, GameCommand.StartGame)
+        }
+    }
+
+    @Test
+    fun test_addPlayer_rejectsWhenFull() {
+        var state = GameState()
+        for (i in 1..5) {
+            state = stateMachine.apply(state, GameCommand.AddPlayer("p$i", "Player $i"))
+        }
+
+        assertFailsWith<IllegalStateException> {
+            stateMachine.apply(state, GameCommand.AddPlayer("p6", "Player 6"))
+        }
     }
 
     @Test

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -473,11 +473,12 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
-    fun `REVEAL_CARD returns GAME_STATE_UPDATED`() {
+    fun `REVEAL_CARD returns GAME_STATE_UPDATED and broadcasts to others`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
+        whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
-        val gameState = GameState(phase = GamePhase.PLAYER_TURN)
-        whenever(gameService.revealNextCard("game-1")).thenReturn(gameState)
+        val gameState = GameState(phase = GamePhase.AUCTION)
+        whenever(gameService.chooseAuction("game-1")).thenReturn(gameState)
 
         val envelope =
             WebSocketEnvelope(
@@ -495,19 +496,31 @@ class GameWebSocketHandlerTest {
             ),
         )
 
-        verify(gameService).revealNextCard("game-1")
+        verify(gameService).chooseAuction("game-1")
 
-        val response = captureResponse(session1)
-        assertEquals(WebSocketType.GAME_STATE_UPDATED, response.type)
-        assertEquals("req-3", response.requestId)
+        val response1 = captureResponse(session1)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response1.type)
+        assertEquals("req-3", response1.requestId)
 
-        val payload =
+        val payload1 =
             WebSocketJson.json.decodeFromJsonElement(
                 GameStatePayload.serializer(),
-                requireNotNull(response.payload),
+                requireNotNull(response1.payload),
             )
 
-        assertEquals(gameState, payload.state)
+        assertEquals(gameState, payload1.state)
+
+        val response2 = captureResponse(session2)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
+        assertNull(response2.requestId)
+
+        val payload2 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response2.payload),
+            )
+
+        assertEquals(gameState, payload2.state)
     }
 
     @Test
@@ -548,7 +561,7 @@ class GameWebSocketHandlerTest {
     @Test
     fun `REVEAL_CARD with missing game returns ERROR`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
-        whenever(gameService.revealNextCard("game-1")).thenReturn(null)
+        whenever(gameService.chooseAuction("game-1")).thenReturn(null)
 
         val envelope =
             WebSocketEnvelope(
@@ -566,7 +579,7 @@ class GameWebSocketHandlerTest {
             ),
         )
 
-        verify(gameService).revealNextCard("game-1")
+        verify(gameService).chooseAuction("game-1")
 
         val response = captureResponse(session1)
         assertEquals(WebSocketType.ERROR, response.type)

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -12,6 +12,7 @@ import at.aau.kuhhandel.shared.websocket.AuctionBuyBackPayload
 import at.aau.kuhhandel.shared.websocket.CreateGamePayload
 import at.aau.kuhhandel.shared.websocket.ErrorPayload
 import at.aau.kuhhandel.shared.websocket.GameCreatedPayload
+import at.aau.kuhhandel.shared.websocket.GameJoinedPayload
 import at.aau.kuhhandel.shared.websocket.GameStatePayload
 import at.aau.kuhhandel.shared.websocket.InitiateTradePayload
 import at.aau.kuhhandel.shared.websocket.JoinGamePayload
@@ -22,7 +23,7 @@ import at.aau.kuhhandel.shared.websocket.WebSocketEnvelope
 import at.aau.kuhhandel.shared.websocket.WebSocketJson
 import at.aau.kuhhandel.shared.websocket.WebSocketType
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
@@ -30,7 +31,6 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.TextMessage
@@ -41,7 +41,8 @@ class GameWebSocketHandlerTest {
     private lateinit var gameService: GameService
     private lateinit var connectionRegistry: ConnectionRegistry
     private lateinit var handler: GameWebSocketHandler
-    private lateinit var session: WebSocketSession
+    private lateinit var session1: WebSocketSession
+    private lateinit var session2: WebSocketSession
 
     @BeforeEach
     fun setUp() {
@@ -49,8 +50,13 @@ class GameWebSocketHandlerTest {
         connectionRegistry = mock(ConnectionRegistry::class.java)
         handler = GameWebSocketHandler(gameService, connectionRegistry)
 
-        session = mock(WebSocketSession::class.java)
-        whenever(session.id).thenReturn("session-1")
+        session1 = mock(WebSocketSession::class.java)
+        whenever(session1.id).thenReturn("session-1")
+        whenever(session1.isOpen).thenReturn(true)
+
+        session2 = mock(WebSocketSession::class.java)
+        whenever(session2.id).thenReturn("session-2")
+        whenever(session2.isOpen).thenReturn(true)
     }
 
     @Test
@@ -58,17 +64,13 @@ class GameWebSocketHandlerTest {
         val gameState = GameState(phase = GamePhase.AUCTION)
         val event = GameStateChangedEvent(gameId = "game-1", newState = gameState)
 
-        val session2 = mock(WebSocketSession::class.java)
-        whenever(session2.isOpen).thenReturn(true)
-        whenever(session.isOpen).thenReturn(true)
-
         whenever(
             connectionRegistry.sessionsFor("game-1"),
-        ).thenReturn(setOf(session, session2))
+        ).thenReturn(setOf(session1, session2))
 
         handler.handleGameStateChanged(event)
 
-        val response1 = captureResponse(session)
+        val response1 = captureResponse(session1)
         assertEquals(WebSocketType.GAME_STATE_UPDATED, response1.type)
 
         val response2 = captureResponse(session2)
@@ -80,12 +82,12 @@ class GameWebSocketHandlerTest {
         val gameState = GameState(phase = GamePhase.AUCTION)
         val event = GameStateChangedEvent(gameId = "game-1", newState = gameState)
 
-        whenever(session.isOpen).thenReturn(false)
-        whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session))
+        whenever(session1.isOpen).thenReturn(false)
+        whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1))
 
         handler.handleGameStateChanged(event)
 
-        verify(session, never()).sendMessage(any())
+        verify(session1, never()).sendMessage(any())
     }
 
     @Test
@@ -107,6 +109,7 @@ class GameWebSocketHandlerTest {
         whenever(gameService.createGame("Player 1")).thenReturn(returnedResult)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.CREATE_GAME,
             requestId = "req-1",
             payload =
@@ -120,7 +123,7 @@ class GameWebSocketHandlerTest {
         verify(connectionRegistry).bindGame("session-1", "game-1")
         verify(connectionRegistry).bindPlayer("session-1", "player-1")
 
-        val response = captureResponse(session)
+        val response = captureResponse(session1)
         assertEquals(WebSocketType.GAME_CREATED, response.type)
         assertEquals("req-1", response.requestId)
 
@@ -135,39 +138,11 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
-    fun `CREATE_GAME uses fallback player name if none provided`() {
-        val createdSession =
-            GameSession(
-                gameId = "game-1",
-                hostPlayerId = "player-1",
-                hostPlayerName = "Player fallback",
-            )
-        val result = RoomActionResult("game-1", "player-1", createdSession.gameState)
-
-        whenever(gameService.createGame(any())).thenReturn(result)
-
-        sendEnvelope(
-            type = WebSocketType.CREATE_GAME,
-            requestId = "req-1",
-            payload =
-                WebSocketJson.json.encodeToJsonElement(
-                    CreateGamePayload.serializer(),
-                    CreateGamePayload(null),
-                ),
-        )
-
-        verify(gameService).createGame(
-            org.mockito.kotlin.check {
-                assertTrue(it.startsWith("Player "))
-            },
-        )
-    }
-
-    @Test
     fun `CREATE_GAME with bound session returns ERROR`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.CREATE_GAME,
             requestId = "req-1",
             payload =
@@ -181,7 +156,7 @@ class GameWebSocketHandlerTest {
         verify(connectionRegistry).gameIdFor("session-1")
         verify(connectionRegistry, never()).bindGame(any(), any())
 
-        val response = captureResponse(session)
+        val response = captureResponse(session1)
         assertEquals(WebSocketType.ERROR, response.type)
         assertEquals("req-1", response.requestId)
 
@@ -195,44 +170,92 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
-    fun `START_GAME returns GAME_STARTED`() {
+    fun `CREATE_GAME does not respond to closed session`() {
+        val createdSession =
+            GameSession(
+                gameId = "game-1",
+                hostPlayerId = "player-1",
+                hostPlayerName = "Player 1",
+            )
+
+        val returnedResult =
+            RoomActionResult(
+                "game-1",
+                "player-1",
+                createdSession.gameState,
+            )
+
+        whenever(session1.isOpen).thenReturn(false)
+        whenever(gameService.createGame("Player 1")).thenReturn(returnedResult)
+
+        sendEnvelope(
+            session = session1,
+            type = WebSocketType.CREATE_GAME,
+            requestId = "req-1",
+            payload =
+                WebSocketJson.json.encodeToJsonElement(
+                    CreateGamePayload.serializer(),
+                    CreateGamePayload("Player 1"),
+                ),
+        )
+
+        verify(session1, never()).sendMessage(any())
+    }
+
+    @Test
+    fun `START_GAME broadcasts GAME_STATE_UPDATED`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
+        whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
         val gameState = GameState(phase = GamePhase.PLAYER_TURN)
         whenever(gameService.startGame("game-1")).thenReturn(gameState)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.START_GAME,
             requestId = "req-2",
         )
 
         verify(gameService).startGame("game-1")
 
-        val response = captureResponse(session)
-        assertEquals(WebSocketType.GAME_STARTED, response.type)
-        assertEquals("req-2", response.requestId)
+        val response1 = captureResponse(session1)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response1.type)
+        assertEquals("req-2", response1.requestId)
 
-        val payload =
+        val payload1 =
             WebSocketJson.json.decodeFromJsonElement(
                 GameStatePayload.serializer(),
-                requireNotNull(response.payload),
+                requireNotNull(response1.payload),
             )
 
-        assertEquals(gameState, payload.state)
+        assertEquals(gameState, payload1.state)
+
+        val response2 = captureResponse(session2)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
+        assertNull(response2.requestId)
+
+        val payload2 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response2.payload),
+            )
+
+        assertEquals(gameState, payload2.state)
     }
 
     @Test
-    fun `START_GAME with no bound game returns ERROR`() {
+    fun `START_GAME with no bound game sends ERROR`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.START_GAME,
             requestId = "req-1",
         )
 
         verifyNoInteractions(gameService)
 
-        val response = captureResponse(session)
+        val response = captureResponse(session1)
         assertEquals(WebSocketType.ERROR, response.type)
         assertEquals("req-1", response.requestId)
 
@@ -251,13 +274,14 @@ class GameWebSocketHandlerTest {
         whenever(gameService.startGame("game-1")).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.START_GAME,
             requestId = "req-2",
         )
 
         verify(gameService).startGame("game-1")
 
-        val response = captureResponse(session)
+        val response = captureResponse(session1)
         assertEquals(WebSocketType.ERROR, response.type)
         assertEquals("req-2", response.requestId)
 
@@ -271,7 +295,7 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
-    fun `JOIN_GAME binds game and player and returns GAME_JOINED`() {
+    fun `JOIN_GAME binds game and player, sends GAME_JOINED, and broadcasts GAME_STATE_UPDATED`() {
         val state =
             GameState(
                 players = listOf(PlayerState("player-1", "Player 1")),
@@ -286,11 +310,14 @@ class GameWebSocketHandlerTest {
             )
 
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn(null)
+        whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
+
         whenever(
-            gameService.joinGame(eq("game-1"), eq("Player 1"), any()),
+            gameService.joinGame("game-1", "Player 1"),
         ).thenReturn(returnedResult)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.JOIN_GAME,
             requestId = "req-1",
             payload =
@@ -300,23 +327,34 @@ class GameWebSocketHandlerTest {
                 ),
         )
 
-        verify(gameService).joinGame(eq("game-1"), eq("Player 1"), eq("req-1"))
+        verify(gameService).joinGame("game-1", "Player 1")
         verify(connectionRegistry).bindGame("session-1", "game-1")
         verify(connectionRegistry).bindPlayer("session-1", "player-1")
 
-        val response = captureResponse(session)
-        assertEquals(WebSocketType.GAME_JOINED, response.type)
-        assertEquals("req-1", response.requestId)
+        val response1 = captureResponse(session1)
+        assertEquals(WebSocketType.GAME_JOINED, response1.type)
+        assertEquals("req-1", response1.requestId)
 
-        val payload =
+        val payload1 =
             WebSocketJson.json.decodeFromJsonElement(
-                GameCreatedPayload.serializer(), // re-check this!
-                requireNotNull(response.payload),
+                GameJoinedPayload.serializer(),
+                requireNotNull(response1.payload),
             )
 
-        assertEquals("game-1", payload.gameId)
-        assertEquals("player-1", payload.playerId)
-        assertEquals(state, payload.state)
+        assertEquals("player-1", payload1.playerId)
+        assertEquals(state, payload1.state)
+
+        val response2 = captureResponse(session2)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
+        assertNull(response2.requestId)
+
+        val payload2 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response2.payload),
+            )
+
+        assertEquals(state, payload2.state)
     }
 
     @Test
@@ -324,6 +362,7 @@ class GameWebSocketHandlerTest {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.JOIN_GAME,
             requestId = "req-1",
             payload =
@@ -338,36 +377,10 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
-    fun `JOIN_GAME uses fallback player name if none provided`() {
-        val state = GameState(players = listOf(PlayerState("player-1", "Player 1")))
-        val result = RoomActionResult("game-1", "player-1", state)
-
-        whenever(gameService.joinGame(any(), any(), any())).thenReturn(result)
-
-        sendEnvelope(
-            type = WebSocketType.JOIN_GAME,
-            requestId = "req-1",
-            payload =
-                WebSocketJson.json.encodeToJsonElement(
-                    JoinGamePayload.serializer(),
-                    JoinGamePayload("game-1", null),
-                ),
-        )
-
-        verify(gameService).joinGame(
-            eq("game-1"),
-            org.mockito.kotlin.check {
-                assertTrue(it.startsWith("Player "))
-            },
-            eq("req-1"),
-        )
-    }
-
-    @Test
     fun `JOIN_GAME with missing payload returns ERROR`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn(null)
 
-        sendEnvelope(type = WebSocketType.JOIN_GAME, requestId = "req-1")
+        sendEnvelope(session = session1, type = WebSocketType.JOIN_GAME, requestId = "req-1")
 
         assertErrorResponse("Missing payload for JOIN_GAME")
     }
@@ -377,6 +390,7 @@ class GameWebSocketHandlerTest {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.JOIN_GAME,
             requestId = "req-1",
             payload =
@@ -390,22 +404,43 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
-    fun `LEAVE_GAME unbinds session and returns GAME_LEFT`() {
+    fun `LEAVE_GAME unbinds session, sends GAME_LEFT, and broadcasts GAME_STATE_UPDATED`() {
+        val returnedState =
+            GameState(
+                players = listOf(PlayerState("player-1", "Player 1")),
+                hostPlayerId = "player-1",
+            )
+
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
         whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
-        whenever(gameService.leaveGame("game-1", "Player 1")).thenReturn(GameState())
+        whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session2))
+
+        whenever(gameService.leaveGame("game-1", "player-1")).thenReturn(returnedState)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.LEAVE_GAME,
             requestId = "req-1",
         )
 
-        verify(gameService).leaveGame("game-1", "player-1", "req-1")
+        verify(gameService).leaveGame("game-1", "player-1")
         verify(connectionRegistry).unbind("session-1")
 
-        val response = captureResponse(session)
-        assertEquals(WebSocketType.GAME_LEFT, response.type)
-        assertEquals("req-1", response.requestId)
+        val response1 = captureResponse(session1)
+        assertEquals(WebSocketType.GAME_LEFT, response1.type)
+        assertEquals("req-1", response1.requestId)
+
+        val response2 = captureResponse(session2)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
+        assertNull(response2.requestId)
+
+        val payload2 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response2.payload),
+            )
+
+        assertEquals(returnedState, payload2.state)
     }
 
     @Test
@@ -413,6 +448,7 @@ class GameWebSocketHandlerTest {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.LEAVE_GAME,
             requestId = "req-1",
         )
@@ -427,6 +463,7 @@ class GameWebSocketHandlerTest {
         whenever(connectionRegistry.playerIdFor("session-1")).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.LEAVE_GAME,
             requestId = "req-1",
         )
@@ -449,7 +486,7 @@ class GameWebSocketHandlerTest {
             )
 
         handler.handleMessage(
-            session,
+            session1,
             TextMessage(
                 WebSocketJson.json.encodeToString(
                     WebSocketEnvelope.serializer(),
@@ -460,7 +497,7 @@ class GameWebSocketHandlerTest {
 
         verify(gameService).revealNextCard("game-1")
 
-        val response = captureResponse(session)
+        val response = captureResponse(session1)
         assertEquals(WebSocketType.GAME_STATE_UPDATED, response.type)
         assertEquals("req-3", response.requestId)
 
@@ -484,7 +521,7 @@ class GameWebSocketHandlerTest {
             )
 
         handler.handleMessage(
-            session,
+            session1,
             TextMessage(
                 WebSocketJson.json.encodeToString(
                     WebSocketEnvelope.serializer(),
@@ -495,7 +532,7 @@ class GameWebSocketHandlerTest {
 
         verifyNoInteractions(gameService)
 
-        val response = captureResponse(session)
+        val response = captureResponse(session1)
         assertEquals(WebSocketType.ERROR, response.type)
         assertEquals("req-3", response.requestId)
 
@@ -520,7 +557,7 @@ class GameWebSocketHandlerTest {
             )
 
         handler.handleMessage(
-            session,
+            session1,
             TextMessage(
                 WebSocketJson.json.encodeToString(
                     WebSocketEnvelope.serializer(),
@@ -531,7 +568,7 @@ class GameWebSocketHandlerTest {
 
         verify(gameService).revealNextCard("game-1")
 
-        val response = captureResponse(session)
+        val response = captureResponse(session1)
         assertEquals(WebSocketType.ERROR, response.type)
         assertEquals("req-4", response.requestId)
 
@@ -546,9 +583,9 @@ class GameWebSocketHandlerTest {
 
     @Test
     fun `invalid message format returns ERROR`() {
-        handler.handleMessage(session, TextMessage("HELLO"))
+        handler.handleMessage(session1, TextMessage("HELLO"))
 
-        val response = captureResponse(session)
+        val response = captureResponse(session1)
         assertEquals(WebSocketType.ERROR, response.type)
 
         val payload =
@@ -571,7 +608,7 @@ class GameWebSocketHandlerTest {
             )
 
         handler.handleMessage(
-            session,
+            session1,
             TextMessage(
                 WebSocketJson.json.encodeToString(
                     WebSocketEnvelope.serializer(),
@@ -580,7 +617,7 @@ class GameWebSocketHandlerTest {
             ),
         )
 
-        val response = captureResponse(session)
+        val response = captureResponse(session1)
         assertEquals(WebSocketType.ERROR, response.type)
         assertEquals("req-unsupported", response.requestId)
 
@@ -597,21 +634,22 @@ class GameWebSocketHandlerTest {
 
     @Test
     fun `afterConnectionEstablished binds session`() {
-        handler.afterConnectionEstablished(session)
+        handler.afterConnectionEstablished(session1)
 
-        verify(connectionRegistry).bindSession(session)
+        verify(connectionRegistry).bindSession(session1)
     }
 
     @Test
     fun `afterConnectionClosed unbinds session`() {
-        handler.afterConnectionClosed(session, CloseStatus.NORMAL)
+        handler.afterConnectionClosed(session1, CloseStatus.NORMAL)
 
         verify(connectionRegistry).unbind("session-1")
     }
 
     @Test
-    fun `INITIATE_TRADE happy path returns GAME_STATE_UPDATED`() {
+    fun `INITIATE_TRADE happy path broadcasts GAME_STATE_UPDATED`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
+        whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
         val gameState = GameState(phase = GamePhase.TRADE)
         whenever(
@@ -619,6 +657,7 @@ class GameWebSocketHandlerTest {
         ).thenReturn(gameState)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.INITIATE_TRADE,
             requestId = "req-trade-1",
             payload =
@@ -634,9 +673,29 @@ class GameWebSocketHandlerTest {
 
         verify(gameService).chooseTrade("game-1", "player-2", AnimalType.COW, emptyList())
 
-        val response = captureResponse(session)
-        assertEquals(WebSocketType.GAME_STATE_UPDATED, response.type)
-        assertEquals("req-trade-1", response.requestId)
+        val response1 = captureResponse(session1)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response1.type)
+        assertEquals("req-trade-1", response1.requestId)
+
+        val payload1 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response1.payload),
+            )
+
+        assertEquals(gameState, payload1.state)
+
+        val response2 = captureResponse(session2)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
+        assertNull(response2.requestId)
+
+        val payload2 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response2.payload),
+            )
+
+        assertEquals(gameState, payload2.state)
     }
 
     @Test
@@ -644,6 +703,7 @@ class GameWebSocketHandlerTest {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.INITIATE_TRADE,
             requestId = "req-trade-2",
             payload =
@@ -665,7 +725,11 @@ class GameWebSocketHandlerTest {
     fun `INITIATE_TRADE with missing payload returns ERROR`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
 
-        sendEnvelope(type = WebSocketType.INITIATE_TRADE, requestId = "req-trade-3")
+        sendEnvelope(
+            session = session1,
+            type = WebSocketType.INITIATE_TRADE,
+            requestId = "req-trade-3",
+        )
 
         assertErrorResponse("Missing payload for INITIATE_TRADE")
     }
@@ -675,6 +739,7 @@ class GameWebSocketHandlerTest {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.INITIATE_TRADE,
             requestId = "req-trade-4",
             payload =
@@ -694,6 +759,7 @@ class GameWebSocketHandlerTest {
             .thenThrow(IllegalArgumentException("Unknown challenged player player-2"))
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.INITIATE_TRADE,
             requestId = "req-trade-5",
             payload =
@@ -717,6 +783,7 @@ class GameWebSocketHandlerTest {
             .thenThrow(IllegalStateException("Cannot start a trade during phase NOT_STARTED"))
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.INITIATE_TRADE,
             requestId = "req-trade-6",
             payload =
@@ -741,6 +808,7 @@ class GameWebSocketHandlerTest {
         ).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.INITIATE_TRADE,
             requestId = "req-trade-7",
             payload =
@@ -758,13 +826,15 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
-    fun `OFFER_TRADE happy path returns GAME_STATE_UPDATED`() {
+    fun `OFFER_TRADE happy path broadcasts GAME_STATE_UPDATED`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
+        whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
         val gameState = GameState(phase = GamePhase.TRADE)
         whenever(gameService.offerTrade("game-1", listOf("m-10"))).thenReturn(gameState)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.OFFER_TRADE,
             requestId = "req-offer-1",
             payload =
@@ -776,9 +846,29 @@ class GameWebSocketHandlerTest {
 
         verify(gameService).offerTrade("game-1", listOf("m-10"))
 
-        val response = captureResponse(session)
-        assertEquals(WebSocketType.GAME_STATE_UPDATED, response.type)
-        assertEquals("req-offer-1", response.requestId)
+        val response1 = captureResponse(session1)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response1.type)
+        assertEquals("req-offer-1", response1.requestId)
+
+        val payload1 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response1.payload),
+            )
+
+        assertEquals(gameState, payload1.state)
+
+        val response2 = captureResponse(session2)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
+        assertNull(response2.requestId)
+
+        val payload2 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response2.payload),
+            )
+
+        assertEquals(gameState, payload2.state)
     }
 
     @Test
@@ -786,6 +876,7 @@ class GameWebSocketHandlerTest {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.OFFER_TRADE,
             requestId = "req-offer-2",
             payload =
@@ -806,6 +897,7 @@ class GameWebSocketHandlerTest {
             .thenThrow(IllegalArgumentException("Player player-1 does not own money card m-10"))
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.OFFER_TRADE,
             requestId = "req-offer-3",
             payload =
@@ -825,6 +917,7 @@ class GameWebSocketHandlerTest {
             .thenThrow(IllegalStateException("Cannot offer money for a trade during phase AUCTION"))
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.OFFER_TRADE,
             requestId = "req-offer-4",
             payload =
@@ -843,6 +936,7 @@ class GameWebSocketHandlerTest {
         whenever(gameService.offerTrade("game-1", listOf("m-10"))).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.OFFER_TRADE,
             requestId = "req-offer-5",
             payload =
@@ -856,13 +950,15 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
-    fun `RESPOND_TO_TRADE happy path returns GAME_STATE_UPDATED`() {
+    fun `RESPOND_TO_TRADE happy path broadcasts GAME_STATE_UPDATED`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
+        whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
         val gameState = GameState(phase = GamePhase.ROUND_END)
         whenever(gameService.respondToTrade("game-1", "player-2", true)).thenReturn(gameState)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.RESPOND_TO_TRADE,
             requestId = "req-resp-1",
             payload =
@@ -878,9 +974,29 @@ class GameWebSocketHandlerTest {
 
         verify(gameService).respondToTrade("game-1", "player-2", true)
 
-        val response = captureResponse(session)
-        assertEquals(WebSocketType.GAME_STATE_UPDATED, response.type)
-        assertEquals("req-resp-1", response.requestId)
+        val response1 = captureResponse(session1)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response1.type)
+        assertEquals("req-resp-1", response1.requestId)
+
+        val payload1 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response1.payload),
+            )
+
+        assertEquals(gameState, payload1.state)
+
+        val response2 = captureResponse(session2)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
+        assertNull(response2.requestId)
+
+        val payload2 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response2.payload),
+            )
+
+        assertEquals(gameState, payload2.state)
     }
 
     @Test
@@ -888,6 +1004,7 @@ class GameWebSocketHandlerTest {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.RESPOND_TO_TRADE,
             requestId = "req-resp-2",
             payload =
@@ -913,6 +1030,7 @@ class GameWebSocketHandlerTest {
             .thenThrow(IllegalArgumentException(errorMessage))
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.RESPOND_TO_TRADE,
             requestId = "req-resp-3",
             payload =
@@ -936,6 +1054,7 @@ class GameWebSocketHandlerTest {
             .thenThrow(IllegalStateException("Cannot respond to a trade during phase AUCTION"))
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.RESPOND_TO_TRADE,
             requestId = "req-resp-4",
             payload =
@@ -958,6 +1077,7 @@ class GameWebSocketHandlerTest {
         whenever(gameService.respondToTrade("game-1", "player-2", false)).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.RESPOND_TO_TRADE,
             requestId = "req-resp-5",
             payload =
@@ -975,14 +1095,16 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
-    fun `PLACE_BID happy path returns GAME_STATE_UPDATED`() {
+    fun `PLACE_BID happy path broadcasts GAME_STATE_UPDATED`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
         whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
+        whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
         val gameState = GameState(phase = GamePhase.AUCTION)
         whenever(gameService.placeBid("game-1", "player-1", 100)).thenReturn(gameState)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.PLACE_BID,
             requestId = "req-bid-1",
             payload =
@@ -994,9 +1116,29 @@ class GameWebSocketHandlerTest {
 
         verify(gameService).placeBid("game-1", "player-1", 100)
 
-        val response = captureResponse(session)
-        assertEquals(WebSocketType.GAME_STATE_UPDATED, response.type)
-        assertEquals("req-bid-1", response.requestId)
+        val response1 = captureResponse(session1)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response1.type)
+        assertEquals("req-bid-1", response1.requestId)
+
+        val payload1 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response1.payload),
+            )
+
+        assertEquals(gameState, payload1.state)
+
+        val response2 = captureResponse(session2)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
+        assertNull(response2.requestId)
+
+        val payload2 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response2.payload),
+            )
+
+        assertEquals(gameState, payload2.state)
     }
 
     @Test
@@ -1005,6 +1147,7 @@ class GameWebSocketHandlerTest {
         whenever(connectionRegistry.playerIdFor("session-1")).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.PLACE_BID,
             requestId = "req-bid-1",
             payload =
@@ -1026,6 +1169,7 @@ class GameWebSocketHandlerTest {
         ).thenThrow(RuntimeException("Too low"))
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.PLACE_BID,
             requestId = "req-bid-1",
             payload =
@@ -1045,6 +1189,7 @@ class GameWebSocketHandlerTest {
         whenever(gameService.placeBid("game-1", "player-1", 100)).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.PLACE_BID,
             requestId = "req-bid-2",
             payload =
@@ -1058,13 +1203,15 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
-    fun `AUCTION_BUY_BACK happy path returns GAME_STATE_UPDATED`() {
+    fun `AUCTION_BUY_BACK happy path broadcasts GAME_STATE_UPDATED`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
+        whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
         val gameState = GameState(phase = GamePhase.ROUND_END)
         whenever(gameService.resolveAuction("game-1", true)).thenReturn(gameState)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.AUCTION_BUY_BACK,
             requestId = "req-buyback-1",
             payload =
@@ -1076,9 +1223,29 @@ class GameWebSocketHandlerTest {
 
         verify(gameService).resolveAuction("game-1", true)
 
-        val response = captureResponse(session)
-        assertEquals(WebSocketType.GAME_STATE_UPDATED, response.type)
-        assertEquals("req-buyback-1", response.requestId)
+        val response1 = captureResponse(session1)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response1.type)
+        assertEquals("req-buyback-1", response1.requestId)
+
+        val payload1 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response1.payload),
+            )
+
+        assertEquals(gameState, payload1.state)
+
+        val response2 = captureResponse(session2)
+        assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
+        assertNull(response2.requestId)
+
+        val payload2 =
+            WebSocketJson.json.decodeFromJsonElement(
+                GameStatePayload.serializer(),
+                requireNotNull(response2.payload),
+            )
+
+        assertEquals(gameState, payload2.state)
     }
 
     @Test
@@ -1087,6 +1254,7 @@ class GameWebSocketHandlerTest {
         whenever(gameService.resolveAuction("game-1", true)).thenReturn(null)
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.AUCTION_BUY_BACK,
             requestId = "req-buyback-2",
             payload =
@@ -1105,6 +1273,7 @@ class GameWebSocketHandlerTest {
         whenever(gameService.resolveAuction("game-1", true)).thenThrow(RuntimeException("Error"))
 
         sendEnvelope(
+            session = session1,
             type = WebSocketType.AUCTION_BUY_BACK,
             requestId = "req-buyback-3",
             payload =
@@ -1118,6 +1287,7 @@ class GameWebSocketHandlerTest {
     }
 
     private fun sendEnvelope(
+        session: WebSocketSession,
         type: WebSocketType,
         requestId: String,
         payload: kotlinx.serialization.json.JsonElement? = null,
@@ -1132,7 +1302,7 @@ class GameWebSocketHandlerTest {
     }
 
     private fun assertErrorResponse(expectedMessage: String) {
-        val response = captureResponse(session)
+        val response = captureResponse(session1)
         assertEquals(WebSocketType.ERROR, response.type)
         val payload =
             WebSocketJson.json.decodeFromJsonElement(

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -286,7 +286,7 @@ class GameWebSocketHandlerTest {
             )
 
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn(null)
-        whenever(gameService.joinGame("game-1", "Player 1")).thenReturn(returnedResult)
+        whenever(gameService.joinGame(eq("game-1"), eq("Player 1"), any())).thenReturn(returnedResult)
 
         sendEnvelope(
             type = WebSocketType.JOIN_GAME,

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -549,7 +549,10 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     InitiateTradePayload.serializer(),
-                    InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList()), // re-check this!
+                    InitiateTradePayload(
+                        challengedPlayerId = "player-2",
+                        moneyCardIds = emptyList(),
+                    ), // re-check this!
                 ),
         )
 
@@ -570,7 +573,10 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     InitiateTradePayload.serializer(),
-                    InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList()), // re-check this!
+                    InitiateTradePayload(
+                        challengedPlayerId = "player-2",
+                        moneyCardIds = emptyList(),
+                    ), // re-check this!
                 ),
         )
 
@@ -616,7 +622,10 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     InitiateTradePayload.serializer(),
-                    InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList()), // re-check this!
+                    InitiateTradePayload(
+                        challengedPlayerId = "player-2",
+                        moneyCardIds = emptyList(),
+                    ), // re-check this!
                 ),
         )
 
@@ -635,7 +644,10 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     InitiateTradePayload.serializer(),
-                    InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList()), // re-check this!
+                    InitiateTradePayload(
+                        challengedPlayerId = "player-2",
+                        moneyCardIds = emptyList(),
+                    ), // re-check this!
                 ),
         )
 
@@ -653,7 +665,10 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     InitiateTradePayload.serializer(),
-                    InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList()), // re-check this!
+                    InitiateTradePayload(
+                        challengedPlayerId = "player-2",
+                        moneyCardIds = emptyList(),
+                    ), // re-check this!
                 ),
         )
 
@@ -772,10 +787,10 @@ class GameWebSocketHandlerTest {
                 WebSocketJson.json.encodeToJsonElement(
                     RespondToTradePayload.serializer(),
                     RespondToTradePayload(
-                    respondingPlayerId = "player-2",
-                    accepted = true,
-                    counterOfferedMoneyCardIds = emptyList() // re-check this!
-                ),
+                        respondingPlayerId = "player-2",
+                        accepted = true,
+                        counterOfferedMoneyCardIds = emptyList(), // re-check this!
+                    ),
                 ),
         )
 
@@ -797,10 +812,10 @@ class GameWebSocketHandlerTest {
                 WebSocketJson.json.encodeToJsonElement(
                     RespondToTradePayload.serializer(),
                     RespondToTradePayload(
-                    respondingPlayerId = "player-2",
-                    accepted = false,
-                    counterOfferedMoneyCardIds = emptyList() // re-check this!
-                ),
+                        respondingPlayerId = "player-2",
+                        accepted = false,
+                        counterOfferedMoneyCardIds = emptyList(), // re-check this!
+                    ),
                 ),
         )
 
@@ -822,10 +837,10 @@ class GameWebSocketHandlerTest {
                 WebSocketJson.json.encodeToJsonElement(
                     RespondToTradePayload.serializer(),
                     RespondToTradePayload(
-                    respondingPlayerId = "player-1",
-                    accepted = true,
-                    counterOfferedMoneyCardIds = emptyList() // re-check this!
-                ),
+                        respondingPlayerId = "player-1",
+                        accepted = true,
+                        counterOfferedMoneyCardIds = emptyList(), // re-check this!
+                    ),
                 ),
         )
 
@@ -845,10 +860,10 @@ class GameWebSocketHandlerTest {
                 WebSocketJson.json.encodeToJsonElement(
                     RespondToTradePayload.serializer(),
                     RespondToTradePayload(
-                    respondingPlayerId = "player-2",
-                    accepted = true,
-                    counterOfferedMoneyCardIds = emptyList() // re-check this!
-                ),
+                        respondingPlayerId = "player-2",
+                        accepted = true,
+                        counterOfferedMoneyCardIds = emptyList(), // re-check this!
+                    ),
                 ),
         )
 
@@ -867,10 +882,10 @@ class GameWebSocketHandlerTest {
                 WebSocketJson.json.encodeToJsonElement(
                     RespondToTradePayload.serializer(),
                     RespondToTradePayload(
-                    respondingPlayerId = "player-2",
-                    accepted = false,
-                    counterOfferedMoneyCardIds = emptyList() // re-check this!
-                ),
+                        respondingPlayerId = "player-2",
+                        accepted = false,
+                        counterOfferedMoneyCardIds = emptyList(), // re-check this!
+                    ),
                 ),
         )
 

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -542,7 +542,9 @@ class GameWebSocketHandlerTest {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
 
         val gameState = GameState(phase = GamePhase.TRADE)
-        whenever(gameService.chooseTrade("game-1", "player-2", emptyList())).thenReturn(gameState)
+        whenever(
+            gameService.chooseTrade("game-1", "player-2", AnimalType.COW, emptyList()),
+        ).thenReturn(gameState)
 
         sendEnvelope(
             type = WebSocketType.INITIATE_TRADE,
@@ -558,7 +560,7 @@ class GameWebSocketHandlerTest {
                 ),
         )
 
-        verify(gameService).chooseTrade("game-1", "player-2", emptyList())
+        verify(gameService).chooseTrade("game-1", "player-2", AnimalType.COW, emptyList())
 
         val response = captureResponse(session)
         assertEquals(WebSocketType.GAME_STATE_UPDATED, response.type)
@@ -616,7 +618,7 @@ class GameWebSocketHandlerTest {
     @Test
     fun `INITIATE_TRADE when service rejects with IllegalArgument returns ERROR`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
-        whenever(gameService.chooseTrade("game-1", "player-2", emptyList()))
+        whenever(gameService.chooseTrade("game-1", "player-2", AnimalType.COW, emptyList()))
             .thenThrow(IllegalArgumentException("Unknown challenged player player-2"))
 
         sendEnvelope(
@@ -639,7 +641,7 @@ class GameWebSocketHandlerTest {
     @Test
     fun `INITIATE_TRADE when service rejects with IllegalState returns ERROR`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
-        whenever(gameService.chooseTrade("game-1", "player-2", emptyList()))
+        whenever(gameService.chooseTrade("game-1", "player-2", AnimalType.COW, emptyList()))
             .thenThrow(IllegalStateException("Cannot start a trade during phase NOT_STARTED"))
 
         sendEnvelope(
@@ -662,7 +664,9 @@ class GameWebSocketHandlerTest {
     @Test
     fun `INITIATE_TRADE with missing game returns ERROR`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
-        whenever(gameService.chooseTrade("game-1", "player-2", emptyList())).thenReturn(null)
+        whenever(
+            gameService.chooseTrade("game-1", "player-2", AnimalType.COW, emptyList()),
+        ).thenReturn(null)
 
         sendEnvelope(
             type = WebSocketType.INITIATE_TRADE,

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -156,9 +156,11 @@ class GameWebSocketHandlerTest {
                 ),
         )
 
-        verify(gameService).createGame(org.mockito.kotlin.check {
-            assertTrue(it.startsWith("Player "))
-        })
+        verify(gameService).createGame(
+            org.mockito.kotlin.check {
+                assertTrue(it.startsWith("Player "))
+            },
+        )
     }
 
     @Test
@@ -350,9 +352,12 @@ class GameWebSocketHandlerTest {
                 ),
         )
 
-        verify(gameService).joinGame(eq("game-1"), org.mockito.kotlin.check {
-            assertTrue(it.startsWith("Player "))
-        })
+        verify(gameService).joinGame(
+            eq("game-1"),
+            org.mockito.kotlin.check {
+                assertTrue(it.startsWith("Player "))
+            },
+        )
     }
 
     @Test

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -22,6 +22,7 @@ import at.aau.kuhhandel.shared.websocket.WebSocketEnvelope
 import at.aau.kuhhandel.shared.websocket.WebSocketJson
 import at.aau.kuhhandel.shared.websocket.WebSocketType
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
@@ -29,6 +30,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.TextMessage
@@ -138,12 +140,11 @@ class GameWebSocketHandlerTest {
             GameSession(
                 gameId = "game-1",
                 hostPlayerId = "player-1",
-                hostPlayerName = "Player session-1",
+                hostPlayerName = "Player fallback",
             )
         val result = RoomActionResult("game-1", "player-1", createdSession.gameState)
 
-        whenever(session.id).thenReturn("session-1")
-        whenever(gameService.createGame("Player ion-1")).thenReturn(result)
+        whenever(gameService.createGame(any())).thenReturn(result)
 
         sendEnvelope(
             type = WebSocketType.CREATE_GAME,
@@ -155,7 +156,9 @@ class GameWebSocketHandlerTest {
                 ),
         )
 
-        verify(gameService).createGame("Player ion-1")
+        verify(gameService).createGame(org.mockito.kotlin.check {
+            assertTrue(it.startsWith("Player "))
+        })
     }
 
     @Test
@@ -328,6 +331,28 @@ class GameWebSocketHandlerTest {
 
         verifyNoInteractions(gameService)
         assertErrorResponse("This connection is already bound to a game")
+    }
+
+    @Test
+    fun `JOIN_GAME uses fallback player name if none provided`() {
+        val state = GameState(players = listOf(PlayerState("player-1", "Player 1")))
+        val result = RoomActionResult("game-1", "player-1", state)
+
+        whenever(gameService.joinGame(any(), any())).thenReturn(result)
+
+        sendEnvelope(
+            type = WebSocketType.JOIN_GAME,
+            requestId = "req-1",
+            payload =
+                WebSocketJson.json.encodeToJsonElement(
+                    JoinGamePayload.serializer(),
+                    JoinGamePayload("game-1", null),
+                ),
+        )
+
+        verify(gameService).joinGame(eq("game-1"), org.mockito.kotlin.check {
+            assertTrue(it.startsWith("Player "))
+        })
     }
 
     @Test

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -263,11 +263,12 @@ class GameWebSocketHandlerTest {
 
         val payload =
             WebSocketJson.json.decodeFromJsonElement(
-                GameStatePayload.serializer(),
+                GameCreatedPayload.serializer(), // re-check this!
                 requireNotNull(response.payload),
             )
 
-        assertEquals("player-1", payload.state.hostPlayerId)
+        assertEquals("game-1", payload.gameId)
+        assertEquals("player-1", payload.playerId)
         assertEquals(state, payload.state)
     }
 
@@ -548,7 +549,7 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     InitiateTradePayload.serializer(),
-                    InitiateTradePayload(challengedPlayerId = "player-2"),
+                    InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList()), // re-check this!
                 ),
         )
 
@@ -569,7 +570,7 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     InitiateTradePayload.serializer(),
-                    InitiateTradePayload(challengedPlayerId = "player-2"),
+                    InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList()), // re-check this!
                 ),
         )
 
@@ -615,7 +616,7 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     InitiateTradePayload.serializer(),
-                    InitiateTradePayload(challengedPlayerId = "player-2"),
+                    InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList()), // re-check this!
                 ),
         )
 
@@ -634,7 +635,7 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     InitiateTradePayload.serializer(),
-                    InitiateTradePayload(challengedPlayerId = "player-2"),
+                    InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList()), // re-check this!
                 ),
         )
 
@@ -652,7 +653,7 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     InitiateTradePayload.serializer(),
-                    InitiateTradePayload(challengedPlayerId = "player-2"),
+                    InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList()), // re-check this!
                 ),
         )
 
@@ -770,7 +771,11 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     RespondToTradePayload.serializer(),
-                    RespondToTradePayload(respondingPlayerId = "player-2", accepted = true),
+                    RespondToTradePayload(
+                    respondingPlayerId = "player-2",
+                    accepted = true,
+                    counterOfferedMoneyCardIds = emptyList() // re-check this!
+                ),
                 ),
         )
 
@@ -791,7 +796,11 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     RespondToTradePayload.serializer(),
-                    RespondToTradePayload(respondingPlayerId = "player-2", accepted = false),
+                    RespondToTradePayload(
+                    respondingPlayerId = "player-2",
+                    accepted = false,
+                    counterOfferedMoneyCardIds = emptyList() // re-check this!
+                ),
                 ),
         )
 
@@ -812,7 +821,11 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     RespondToTradePayload.serializer(),
-                    RespondToTradePayload(respondingPlayerId = "player-1", accepted = true),
+                    RespondToTradePayload(
+                    respondingPlayerId = "player-1",
+                    accepted = true,
+                    counterOfferedMoneyCardIds = emptyList() // re-check this!
+                ),
                 ),
         )
 
@@ -831,7 +844,11 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     RespondToTradePayload.serializer(),
-                    RespondToTradePayload(respondingPlayerId = "player-2", accepted = true),
+                    RespondToTradePayload(
+                    respondingPlayerId = "player-2",
+                    accepted = true,
+                    counterOfferedMoneyCardIds = emptyList() // re-check this!
+                ),
                 ),
         )
 
@@ -849,7 +866,11 @@ class GameWebSocketHandlerTest {
             payload =
                 WebSocketJson.json.encodeToJsonElement(
                     RespondToTradePayload.serializer(),
-                    RespondToTradePayload(respondingPlayerId = "player-2", accepted = false),
+                    RespondToTradePayload(
+                    respondingPlayerId = "player-2",
+                    accepted = false,
+                    counterOfferedMoneyCardIds = emptyList() // re-check this!
+                ),
                 ),
         )
 

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -298,7 +298,7 @@ class GameWebSocketHandlerTest {
                 ),
         )
 
-        verify(gameService).joinGame("game-1", "Player 1")
+        verify(gameService).joinGame(eq("game-1"), eq("Player 1"), eq("req-1"))
         verify(connectionRegistry).bindGame("session-1", "game-1")
         verify(connectionRegistry).bindPlayer("session-1", "player-1")
 
@@ -340,7 +340,7 @@ class GameWebSocketHandlerTest {
         val state = GameState(players = listOf(PlayerState("player-1", "Player 1")))
         val result = RoomActionResult("game-1", "player-1", state)
 
-        whenever(gameService.joinGame(any(), any())).thenReturn(result)
+        whenever(gameService.joinGame(any(), any(), any())).thenReturn(result)
 
         sendEnvelope(
             type = WebSocketType.JOIN_GAME,
@@ -357,6 +357,7 @@ class GameWebSocketHandlerTest {
             org.mockito.kotlin.check {
                 assertTrue(it.startsWith("Player "))
             },
+            eq("req-1"),
         )
     }
 
@@ -397,7 +398,7 @@ class GameWebSocketHandlerTest {
             requestId = "req-1",
         )
 
-        verify(gameService).leaveGame("game-1", "player-1")
+        verify(gameService).leaveGame("game-1", "player-1", "req-1")
         verify(connectionRegistry).unbind("session-1")
 
         val response = captureResponse(session)

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -4,6 +4,7 @@ import at.aau.kuhhandel.server.event.GameStateChangedEvent
 import at.aau.kuhhandel.server.model.GameSession
 import at.aau.kuhhandel.server.model.RoomActionResult
 import at.aau.kuhhandel.server.service.GameService
+import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.enums.GamePhase
 import at.aau.kuhhandel.shared.model.GameState
 import at.aau.kuhhandel.shared.model.PlayerState
@@ -541,7 +542,7 @@ class GameWebSocketHandlerTest {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
 
         val gameState = GameState(phase = GamePhase.TRADE)
-        whenever(gameService.chooseTrade("game-1", "player-2")).thenReturn(gameState)
+        whenever(gameService.chooseTrade("game-1", "player-2", emptyList())).thenReturn(gameState)
 
         sendEnvelope(
             type = WebSocketType.INITIATE_TRADE,
@@ -551,12 +552,13 @@ class GameWebSocketHandlerTest {
                     InitiateTradePayload.serializer(),
                     InitiateTradePayload(
                         challengedPlayerId = "player-2",
+                        animalType = AnimalType.COW,
                         moneyCardIds = emptyList(),
-                    ), // re-check this!
+                    ),
                 ),
         )
 
-        verify(gameService).chooseTrade("game-1", "player-2")
+        verify(gameService).chooseTrade("game-1", "player-2", emptyList())
 
         val response = captureResponse(session)
         assertEquals(WebSocketType.GAME_STATE_UPDATED, response.type)
@@ -575,8 +577,9 @@ class GameWebSocketHandlerTest {
                     InitiateTradePayload.serializer(),
                     InitiateTradePayload(
                         challengedPlayerId = "player-2",
+                        animalType = AnimalType.COW,
                         moneyCardIds = emptyList(),
-                    ), // re-check this!
+                    ),
                 ),
         )
 
@@ -613,7 +616,7 @@ class GameWebSocketHandlerTest {
     @Test
     fun `INITIATE_TRADE when service rejects with IllegalArgument returns ERROR`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
-        whenever(gameService.chooseTrade("game-1", "player-2"))
+        whenever(gameService.chooseTrade("game-1", "player-2", emptyList()))
             .thenThrow(IllegalArgumentException("Unknown challenged player player-2"))
 
         sendEnvelope(
@@ -624,8 +627,9 @@ class GameWebSocketHandlerTest {
                     InitiateTradePayload.serializer(),
                     InitiateTradePayload(
                         challengedPlayerId = "player-2",
+                        animalType = AnimalType.COW,
                         moneyCardIds = emptyList(),
-                    ), // re-check this!
+                    ),
                 ),
         )
 
@@ -635,7 +639,7 @@ class GameWebSocketHandlerTest {
     @Test
     fun `INITIATE_TRADE when service rejects with IllegalState returns ERROR`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
-        whenever(gameService.chooseTrade("game-1", "player-2"))
+        whenever(gameService.chooseTrade("game-1", "player-2", emptyList()))
             .thenThrow(IllegalStateException("Cannot start a trade during phase NOT_STARTED"))
 
         sendEnvelope(
@@ -646,8 +650,9 @@ class GameWebSocketHandlerTest {
                     InitiateTradePayload.serializer(),
                     InitiateTradePayload(
                         challengedPlayerId = "player-2",
+                        animalType = AnimalType.COW,
                         moneyCardIds = emptyList(),
-                    ), // re-check this!
+                    ),
                 ),
         )
 
@@ -657,7 +662,7 @@ class GameWebSocketHandlerTest {
     @Test
     fun `INITIATE_TRADE with missing game returns ERROR`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
-        whenever(gameService.chooseTrade("game-1", "player-2")).thenReturn(null)
+        whenever(gameService.chooseTrade("game-1", "player-2", emptyList())).thenReturn(null)
 
         sendEnvelope(
             type = WebSocketType.INITIATE_TRADE,
@@ -667,8 +672,9 @@ class GameWebSocketHandlerTest {
                     InitiateTradePayload.serializer(),
                     InitiateTradePayload(
                         challengedPlayerId = "player-2",
+                        animalType = AnimalType.COW,
                         moneyCardIds = emptyList(),
-                    ), // re-check this!
+                    ),
                 ),
         )
 
@@ -895,6 +901,7 @@ class GameWebSocketHandlerTest {
     @Test
     fun `PLACE_BID happy path returns GAME_STATE_UPDATED`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
+        whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
 
         val gameState = GameState(phase = GamePhase.AUCTION)
         whenever(gameService.placeBid("game-1", "player-1", 100)).thenReturn(gameState)
@@ -919,6 +926,7 @@ class GameWebSocketHandlerTest {
     @Test
     fun `PLACE_BID with missing game returns ERROR`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
+        whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
         whenever(gameService.placeBid("game-1", "player-1", 100)).thenReturn(null)
 
         sendEnvelope(

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -286,7 +286,9 @@ class GameWebSocketHandlerTest {
             )
 
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn(null)
-        whenever(gameService.joinGame(eq("game-1"), eq("Player 1"), any())).thenReturn(returnedResult)
+        whenever(
+            gameService.joinGame(eq("game-1"), eq("Player 1"), any()),
+        ).thenReturn(returnedResult)
 
         sendEnvelope(
             type = WebSocketType.JOIN_GAME,

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -74,6 +74,19 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
+    fun `handleGameStateChanged skips closed sessions`() {
+        val gameState = GameState(phase = GamePhase.AUCTION)
+        val event = GameStateChangedEvent(gameId = "game-1", newState = gameState)
+
+        whenever(session.isOpen).thenReturn(false)
+        whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session))
+
+        handler.handleGameStateChanged(event)
+
+        verify(session, never()).sendMessage(any())
+    }
+
+    @Test
     fun `CREATE_GAME binds session and returns GAME_CREATED`() {
         val createdSession =
             GameSession(
@@ -117,6 +130,32 @@ class GameWebSocketHandlerTest {
 
         assertEquals("game-1", payload.gameId)
         assertEquals(createdSession.gameState, payload.state)
+    }
+
+    @Test
+    fun `CREATE_GAME uses fallback player name if none provided`() {
+        val createdSession =
+            GameSession(
+                gameId = "game-1",
+                hostPlayerId = "player-1",
+                hostPlayerName = "Player session-1",
+            )
+        val result = RoomActionResult("game-1", "player-1", createdSession.gameState)
+
+        whenever(session.id).thenReturn("session-1")
+        whenever(gameService.createGame("Player ion-1")).thenReturn(result)
+
+        sendEnvelope(
+            type = WebSocketType.CREATE_GAME,
+            requestId = "req-1",
+            payload =
+                WebSocketJson.json.encodeToJsonElement(
+                    CreateGamePayload.serializer(),
+                    CreateGamePayload(null),
+                ),
+        )
+
+        verify(gameService).createGame("Player ion-1")
     }
 
     @Test
@@ -928,6 +967,45 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
+    fun `PLACE_BID with missing player bound returns ERROR`() {
+        whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
+        whenever(connectionRegistry.playerIdFor("session-1")).thenReturn(null)
+
+        sendEnvelope(
+            type = WebSocketType.PLACE_BID,
+            requestId = "req-bid-1",
+            payload =
+                WebSocketJson.json.encodeToJsonElement(
+                    PlaceBidPayload.serializer(),
+                    PlaceBidPayload(amount = 100),
+                ),
+        )
+
+        assertErrorResponse("No player bound to this connection")
+    }
+
+    @Test
+    fun `PLACE_BID when service throws exception returns ERROR`() {
+        whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
+        whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
+        whenever(
+            gameService.placeBid("game-1", "player-1", 100),
+        ).thenThrow(RuntimeException("Too low"))
+
+        sendEnvelope(
+            type = WebSocketType.PLACE_BID,
+            requestId = "req-bid-1",
+            payload =
+                WebSocketJson.json.encodeToJsonElement(
+                    PlaceBidPayload.serializer(),
+                    PlaceBidPayload(amount = 100),
+                ),
+        )
+
+        assertErrorResponse("Too low")
+    }
+
+    @Test
     fun `PLACE_BID with missing game returns ERROR`() {
         whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
         whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
@@ -986,6 +1064,24 @@ class GameWebSocketHandlerTest {
         )
 
         assertErrorResponse("Game not found")
+    }
+
+    @Test
+    fun `AUCTION_BUY_BACK when service throws returns ERROR`() {
+        whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
+        whenever(gameService.resolveAuction("game-1", true)).thenThrow(RuntimeException("Error"))
+
+        sendEnvelope(
+            type = WebSocketType.AUCTION_BUY_BACK,
+            requestId = "req-buyback-3",
+            payload =
+                WebSocketJson.json.encodeToJsonElement(
+                    AuctionBuyBackPayload.serializer(),
+                    AuctionBuyBackPayload(buyBack = true),
+                ),
+        )
+
+        assertErrorResponse("Error")
     }
 
     private fun sendEnvelope(

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
@@ -13,7 +13,7 @@ data class CreateGamePayload(
 )
 
 /**
- * Payload used by GAME_CREATED events
+ * Payload used by GAME_CREATED and GAME_JOINED events
  */
 @Serializable
 data class GameCreatedPayload(
@@ -23,7 +23,7 @@ data class GameCreatedPayload(
 )
 
 /**
- * Payload used by GAME_STARTED, GAME_JOINED, and GAME_STATE_UPDATED events
+ * Payload used by GAME_STARTED and GAME_STATE_UPDATED events
  */
 @Serializable
 data class GameStatePayload(

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
@@ -17,6 +17,7 @@ data class CreateGamePayload(
 @Serializable
 data class GameCreatedPayload(
     val gameId: String,
+    val playerId: String,
     val state: GameState,
 )
 

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
@@ -13,12 +13,12 @@ data class CreateGamePayload(
 )
 
 /**
- * Payload used by GAME_CREATED and GAME_JOINED events
+ * Payload used by GAME_CREATED events
  */
 @Serializable
 data class GameCreatedPayload(
     val gameId: String,
-    val playerId: String = "unknown-player",
+    val playerId: String,
     val state: GameState,
 )
 
@@ -37,6 +37,15 @@ data class GameStatePayload(
 data class JoinGamePayload(
     val gameId: String,
     val playerName: String? = null,
+)
+
+/**
+ * Payload used by GAME_JOINED events
+ */
+@Serializable
+data class GameJoinedPayload(
+    val playerId: String,
+    val state: GameState,
 )
 
 /**

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
@@ -18,7 +18,7 @@ data class CreateGamePayload(
 @Serializable
 data class GameCreatedPayload(
     val gameId: String,
-    val playerId: String,
+    val playerId: String = "unknown-player",
     val state: GameState,
 )
 

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
@@ -53,6 +53,7 @@ data class ErrorPayload(
 @Serializable
 data class InitiateTradePayload(
     val challengedPlayerId: String,
+    val moneyCardIds: List<String> = emptyList(), // re-check this!
 )
 
 /**
@@ -73,6 +74,7 @@ data class OfferTradePayload(
 data class RespondToTradePayload(
     val respondingPlayerId: String,
     val accepted: Boolean,
+    val counterOfferedMoneyCardIds: List<String> = emptyList(), // re-check this!
 )
 
 /**

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
@@ -1,5 +1,6 @@
 package at.aau.kuhhandel.shared.websocket
 
+import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.model.GameState
 import kotlinx.serialization.Serializable
 
@@ -53,7 +54,8 @@ data class ErrorPayload(
 @Serializable
 data class InitiateTradePayload(
     val challengedPlayerId: String,
-    val moneyCardIds: List<String> = emptyList(), // re-check this!
+    val animalType: AnimalType,
+    val moneyCardIds: List<String> = emptyList(),
 )
 
 /**

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
@@ -69,7 +69,7 @@ class WebSocketProtocolTest {
 
     @Test
     fun `GameCreatedPayload round-trips`() {
-        val payload = GameCreatedPayload(gameId = "Id", state = GameState())
+        val payload = GameCreatedPayload(gameId = "Id", playerId = "P1", state = GameState()) // re-check this!
 
         val encoded = json.encodeToString(GameCreatedPayload.serializer(), payload)
         val decoded = json.decodeFromString(GameCreatedPayload.serializer(), encoded)
@@ -118,7 +118,7 @@ class WebSocketProtocolTest {
 
     @Test
     fun `InitiateTradePayload round-trips and exposes its fields`() {
-        val payload = InitiateTradePayload(challengedPlayerId = "player-2")
+        val payload = InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList()) // re-check this!
 
         assertEquals("player-2", payload.challengedPlayerId)
 
@@ -152,6 +152,7 @@ class WebSocketProtocolTest {
             RespondToTradePayload(
                 respondingPlayerId = "player-2",
                 accepted = true,
+                counterOfferedMoneyCardIds = emptyList(), // re-check this!
             )
 
         assertEquals("player-2", payload.respondingPlayerId)

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
@@ -124,7 +124,7 @@ class WebSocketProtocolTest {
             InitiateTradePayload(
                 challengedPlayerId = "player-2",
                 animalType = AnimalType.COW,
-                moneyCardIds = emptyList()
+                moneyCardIds = emptyList(),
             )
 
         assertEquals("player-2", payload.challengedPlayerId)

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
@@ -69,7 +69,8 @@ class WebSocketProtocolTest {
 
     @Test
     fun `GameCreatedPayload round-trips`() {
-        val payload = GameCreatedPayload(gameId = "Id", playerId = "P1", state = GameState()) // re-check this!
+        // re-check this!
+        val payload = GameCreatedPayload(gameId = "Id", playerId = "P1", state = GameState())
 
         val encoded = json.encodeToString(GameCreatedPayload.serializer(), payload)
         val decoded = json.decodeFromString(GameCreatedPayload.serializer(), encoded)
@@ -118,7 +119,9 @@ class WebSocketProtocolTest {
 
     @Test
     fun `InitiateTradePayload round-trips and exposes its fields`() {
-        val payload = InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList()) // re-check this!
+        val payload =
+            // re-check this!
+            InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList())
 
         assertEquals("player-2", payload.challengedPlayerId)
 

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
@@ -106,6 +106,19 @@ class WebSocketProtocolTest {
     }
 
     @Test
+    fun `GameJoinedPayload round-trips`() {
+        val payload = GameJoinedPayload(playerId = "player-1", state = GameState())
+
+        val encoded = json.encodeToString(GameJoinedPayload.serializer(), payload)
+        val decoded = json.decodeFromString(GameJoinedPayload.serializer(), encoded)
+
+        assertEquals(payload, decoded)
+        assertEquals(payload.hashCode(), decoded.hashCode())
+        assertEquals(payload.toString(), decoded.toString())
+        assertEquals(payload, payload.copy())
+    }
+
+    @Test
     fun `ErrorPayload round-trips`() {
         val payload = ErrorPayload(message = "Something went wrong")
 

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
@@ -1,5 +1,6 @@
 package at.aau.kuhhandel.shared.websocket
 
+import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.model.GameState
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -120,10 +121,14 @@ class WebSocketProtocolTest {
     @Test
     fun `InitiateTradePayload round-trips and exposes its fields`() {
         val payload =
-            // re-check this!
-            InitiateTradePayload(challengedPlayerId = "player-2", moneyCardIds = emptyList())
+            InitiateTradePayload(
+                challengedPlayerId = "player-2",
+                animalType = AnimalType.COW,
+                moneyCardIds = emptyList()
+            )
 
         assertEquals("player-2", payload.challengedPlayerId)
+        assertEquals(AnimalType.COW, payload.animalType)
 
         val encoded = json.encodeToString(InitiateTradePayload.serializer(), payload)
         val decoded = json.decodeFromString(InitiateTradePayload.serializer(), encoded)


### PR DESCRIPTION
/app/
- Implemented **Kuhhandel (Trade)** UI flow: opponent selection, animal choice, and hidden money card selection
- Added **Auction** controls for bidding (bidding amounts) and auctioneer buy-back decisions
- Updated GameViewModel to handle distinct states for both Trade and Auction phases
- Integrated specific network commands for both mechanics in GameRepository
- Added support for leaving games and lobby joining logic

/server/
- Expanded GameStateMachine to handle transitions between Auction and Trade phases
- Implemented logic for processing **hidden trade offers** vs. **public auction bids**
- Updated GameSession with separate persistence for `TradeState` and `AuctionState`
- Enhanced GameWebSocketHandler to route distinct actions (Bid vs. Trade)

/shared/
- Added specific WebSocket payloads for the separate Trade and Bidding lifecycles
- Improved AnimalType propagation across game states
- Expanded protocol tests for both Auction and Trade command flows