### PR TITLE
fix(deploy): cap JVM heap and container memory to stop server thrashing

### DIFF
--- a/deploy/compose.production.yaml
+++ b/deploy/compose.production.yaml
@@ -11,6 +11,10 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://kuhhandel-postgres:5432/kuhhandel_prod
       SPRING_DATASOURCE_USERNAME: ${APP_DB_USER:?APP_DB_USER is required}
       SPRING_DATASOURCE_PASSWORD: ${APP_DB_PASSWORD:?APP_DB_PASSWORD is required}
+      # Cap the JVM heap and use a low-footprint GC so the container fits the 1 GB VM.
+      JAVA_TOOL_OPTIONS: "-Xmx256m -XX:+UseSerialGC -XX:MaxRAMPercentage=60"
+    mem_limit: 384m
+    mem_reservation: 256m
     ports:
       - "127.0.0.1:18080:8080"
     networks:

--- a/deploy/compose.production.yaml
+++ b/deploy/compose.production.yaml
@@ -12,7 +12,7 @@ services:
       SPRING_DATASOURCE_USERNAME: ${APP_DB_USER:?APP_DB_USER is required}
       SPRING_DATASOURCE_PASSWORD: ${APP_DB_PASSWORD:?APP_DB_PASSWORD is required}
       # Cap the JVM heap and use a low-footprint GC so the container fits the 1 GB VM.
-      JAVA_TOOL_OPTIONS: "-Xmx256m -XX:+UseSerialGC -XX:MaxRAMPercentage=60"
+      JAVA_TOOL_OPTIONS: "-Xmx256m -XX:+UseSerialGC"
     mem_limit: 384m
     mem_reservation: 256m
     ports:

--- a/deploy/compose.staging.yaml
+++ b/deploy/compose.staging.yaml
@@ -11,6 +11,10 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://kuhhandel-postgres:5432/kuhhandel_staging
       SPRING_DATASOURCE_USERNAME: ${APP_DB_USER:?APP_DB_USER is required}
       SPRING_DATASOURCE_PASSWORD: ${APP_DB_PASSWORD:?APP_DB_PASSWORD is required}
+      # Cap the JVM heap and use a low-footprint GC so the container fits the 1 GB VM.
+      JAVA_TOOL_OPTIONS: "-Xmx192m -XX:+UseSerialGC -XX:MaxRAMPercentage=60"
+    mem_limit: 320m
+    mem_reservation: 192m
     ports:
       - "127.0.0.1:18081:8080"
     networks:

--- a/deploy/compose.staging.yaml
+++ b/deploy/compose.staging.yaml
@@ -12,7 +12,7 @@ services:
       SPRING_DATASOURCE_USERNAME: ${APP_DB_USER:?APP_DB_USER is required}
       SPRING_DATASOURCE_PASSWORD: ${APP_DB_PASSWORD:?APP_DB_PASSWORD is required}
       # Cap the JVM heap and use a low-footprint GC so the container fits the 1 GB VM.
-      JAVA_TOOL_OPTIONS: "-Xmx192m -XX:+UseSerialGC -XX:MaxRAMPercentage=60"
+      JAVA_TOOL_OPTIONS: "-Xmx192m -XX:+UseSerialGC"
     mem_limit: 320m
     mem_reservation: 192m
     ports:


### PR DESCRIPTION
## Summary

- Cap JVM heap via `JAVA_TOOL_OPTIONS=-Xmx... -XX:+UseSerialGC` in both server compose files
- Set Docker `mem_limit` + `mem_reservation` on production and staging server containers
- VM-side swap (2 GB) was configured manually on the host (out of repo)

## Why

Diagnosed in #177: the server isn't crash-looping (RestartCount = 0, OOMKilled = false) but suffering from **chronic memory pressure** on the 1 GB Google VM:

- Spring Boot startup takes **115–168 s** (should be ~10 s)
- Host runs at `64 MB free, 0 B swap`
- Production and staging Spring containers compete for the same RAM with no JVM caps

With the heap pinned and Docker enforcing memory limits — combined with the 2 GB swap on the host — startup pressure should drop and accidental memory growth is bounded.

## Values chosen

| Container | `JAVA_TOOL_OPTIONS` heap | `mem_limit` | `mem_reservation` |
|---|---|---|---|
| production | `-Xmx256m` | 384 MB | 256 MB |
| staging | `-Xmx192m` | 320 MB | 192 MB |

Asymmetric because staging is mostly idle. Current observed usage was ~150 MB per server, so 256m heap has solid headroom.

## Test plan

- [ ] Deploy to staging first, verify startup time drops and container stays within `mem_limit`
- [ ] Compare `docker stats` over a few hours — no OOM-kill events
- [ ] Promote to production after a stable window

Closes #177.