### PR TITLE
test(deploy): cap JVM heap + container memory (staging probe)

### DIFF
--- a/deploy/compose.production.yaml
+++ b/deploy/compose.production.yaml
@@ -11,6 +11,10 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://kuhhandel-postgres:5432/kuhhandel_prod
       SPRING_DATASOURCE_USERNAME: ${APP_DB_USER:?APP_DB_USER is required}
       SPRING_DATASOURCE_PASSWORD: ${APP_DB_PASSWORD:?APP_DB_PASSWORD is required}
+      # Cap the JVM heap and use a low-footprint GC so the container fits the 1 GB VM.
+      JAVA_TOOL_OPTIONS: "-Xmx256m -XX:+UseSerialGC -XX:MaxRAMPercentage=60"
+    mem_limit: 384m
+    mem_reservation: 256m
     ports:
       - "127.0.0.1:18080:8080"
     networks:

--- a/deploy/compose.staging.yaml
+++ b/deploy/compose.staging.yaml
@@ -11,6 +11,10 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://kuhhandel-postgres:5432/kuhhandel_staging
       SPRING_DATASOURCE_USERNAME: ${APP_DB_USER:?APP_DB_USER is required}
       SPRING_DATASOURCE_PASSWORD: ${APP_DB_PASSWORD:?APP_DB_PASSWORD is required}
+      # Cap the JVM heap and use a low-footprint GC so the container fits the 1 GB VM.
+      JAVA_TOOL_OPTIONS: "-Xmx192m -XX:+UseSerialGC -XX:MaxRAMPercentage=60"
+    mem_limit: 320m
+    mem_reservation: 192m
     ports:
       - "127.0.0.1:18081:8080"
     networks:


### PR DESCRIPTION
## Test deploy of #189 / #177 on staging first

Same patch as #189 (which targets `main`). Merging this into `staging` first triggers `deploy-staging.yml` so we can observe behavior under the new memory caps before promoting to production.

## What to watch on the staging container

- Startup time (`docker logs kuhhandel-server-staging | grep 'Started ServerApplicationKt'`) — expected to drop well below the current ~120 s
- `docker stats kuhhandel-server-staging` — RSS should stay below the 320 MB `mem_limit`
- No OOM-kills: `docker inspect kuhhandel-server-staging --format '{{.State.OOMKilled}} restarts={{.RestartCount}}'`

If staging is stable for a while, merge #189 to roll the same change out to production.

Related: #177, #189.