### PR TITLE
test(deploy): re-probe staging after dropping MaxRAMPercentage

### DIFF
--- a/deploy/compose.production.yaml
+++ b/deploy/compose.production.yaml
@@ -12,7 +12,7 @@ services:
       SPRING_DATASOURCE_USERNAME: ${APP_DB_USER:?APP_DB_USER is required}
       SPRING_DATASOURCE_PASSWORD: ${APP_DB_PASSWORD:?APP_DB_PASSWORD is required}
       # Cap the JVM heap and use a low-footprint GC so the container fits the 1 GB VM.
-      JAVA_TOOL_OPTIONS: "-Xmx256m -XX:+UseSerialGC -XX:MaxRAMPercentage=60"
+      JAVA_TOOL_OPTIONS: "-Xmx256m -XX:+UseSerialGC"
     mem_limit: 384m
     mem_reservation: 256m
     ports:

--- a/deploy/compose.staging.yaml
+++ b/deploy/compose.staging.yaml
@@ -12,7 +12,7 @@ services:
       SPRING_DATASOURCE_USERNAME: ${APP_DB_USER:?APP_DB_USER is required}
       SPRING_DATASOURCE_PASSWORD: ${APP_DB_PASSWORD:?APP_DB_PASSWORD is required}
       # Cap the JVM heap and use a low-footprint GC so the container fits the 1 GB VM.
-      JAVA_TOOL_OPTIONS: "-Xmx192m -XX:+UseSerialGC -XX:MaxRAMPercentage=60"
+      JAVA_TOOL_OPTIONS: "-Xmx192m -XX:+UseSerialGC"
     mem_limit: 320m
     mem_reservation: 192m
     ports:


### PR DESCRIPTION
## Re-test of #189 / #177 on staging

Same patch family as before — now with the `-XX:MaxRAMPercentage=60` flag removed (Copilot review pointed out it's ignored when `-Xmx` is set explicitly, see #190 for the original deploy probe).

Behavior should be identical to the previous staging probe (which already showed startup dropping from ~120 s to ~7.5 s and memory staying well within `mem_limit`), but with a cleaner config that doesn't carry a no-op flag.

## What to verify post-merge

- Startup time still ~7 s
- `docker stats kuhhandel-server-staging` stays under 320 MB
- No OOM-kills

Once stable, promote via #189 to production.

Related: #177, #189, #190.