### PR TITLE
Feat/full deck round flow

### DIFF
--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
@@ -182,6 +182,9 @@ class GameStateMachine {
         require(state.players.any { it.id == command.bidderId }) {
             "Unknown bidder ${command.bidderId}"
         }
+        require(requirePlayer(state.players, command.bidderId).totalMoney() >= command.amount) {
+            "Bidder ${command.bidderId} cannot cover bid ${command.amount}"
+        }
         require(command.amount > auctionState.highestBid) {
             "Bid must be higher than current highest bid"
         }
@@ -233,10 +236,16 @@ class GameStateMachine {
             } else {
                 auctionState.auctioneerId
             }
+        val playersAfterPayment =
+            applyAuctionPayment(
+                players = state.players,
+                auctionState = auctionState,
+                auctioneerBuysCard = command.auctioneerBuysCard,
+            )
 
         return state.copy(
             phase = GamePhase.ROUND_END,
-            players = addAnimalToPlayer(state.players, winnerId, auctionState.auctionCard),
+            players = addAnimalToPlayer(playersAfterPayment, winnerId, auctionState.auctionCard),
             currentFaceUpCard = null,
             auctionState = null,
             tradeState = null,
@@ -517,6 +526,83 @@ class GameStateMachine {
                 player
             }
         }
+    }
+
+    private fun applyAuctionPayment(
+        players: List<PlayerState>,
+        auctionState: AuctionState,
+        auctioneerBuysCard: Boolean,
+    ): List<PlayerState> {
+        val highestBidderId = auctionState.highestBidderId ?: return players
+        if (auctionState.highestBid <= 0) {
+            return players
+        }
+
+        val payerId =
+            if (auctioneerBuysCard) {
+                auctionState.auctioneerId
+            } else {
+                highestBidderId
+            }
+        val receiverId =
+            if (auctioneerBuysCard) {
+                highestBidderId
+            } else {
+                auctionState.auctioneerId
+            }
+        val payer = requirePlayer(players, payerId)
+        val paymentCardIds = selectMoneyCardsForPayment(payer, auctionState.highestBid)
+
+        return transferMoneyCards(
+            players = players,
+            fromPlayerId = payerId,
+            toPlayerId = receiverId,
+            moneyCardIds = paymentCardIds,
+        )
+    }
+
+    private fun selectMoneyCardsForPayment(
+        player: PlayerState,
+        amount: Int,
+    ): List<String> {
+        require(player.totalMoney() >= amount) {
+            "Player ${player.id} cannot cover payment $amount"
+        }
+
+        val bestBySum = mutableMapOf(0 to emptyList<MoneyCard>())
+        val sortedMoneyCards =
+            player.moneyCards
+                .filter { moneyCard -> moneyCard.value > 0 }
+                .sortedWith(
+                    compareBy<MoneyCard> { moneyCard ->
+                        moneyCard.value
+                    }.thenBy { moneyCard ->
+                        moneyCard.id
+                    },
+                )
+
+        sortedMoneyCards.forEach { moneyCard ->
+            val newOptions =
+                bestBySum.mapNotNull { (sum, cards) ->
+                    val newSum = sum + moneyCard.value
+                    if (bestBySum.containsKey(newSum)) {
+                        null
+                    } else {
+                        newSum to cards + moneyCard
+                    }
+                }
+            bestBySum.putAll(newOptions)
+        }
+
+        // Kuhhandel gives no change, so choose the smallest overpayment deterministically.
+        return requireNotNull(
+            bestBySum
+                .filterKeys { sum -> sum >= amount }
+                .minWithOrNull(
+                    compareBy<Map.Entry<Int, List<MoneyCard>>> { (sum, _) -> sum }
+                        .thenBy { (_, cards) -> cards.size },
+                ),
+        ).value.map { moneyCard -> moneyCard.id }
     }
 
     private fun moveAnimalTypeBetweenPlayers(

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
@@ -12,6 +12,13 @@ import at.aau.kuhhandel.shared.model.PlayerState
 import at.aau.kuhhandel.shared.model.TradeState
 
 class GameStateMachine {
+    private companion object {
+        const val CARDS_PER_ANIMAL_TYPE = 4
+        const val INITIAL_ZERO_MONEY_CARDS = 2
+        const val INITIAL_TEN_MONEY_CARDS = 4
+        const val INITIAL_FIFTY_MONEY_CARDS = 1
+    }
+
     fun apply(
         state: GameState,
         command: GameCommand,
@@ -38,6 +45,13 @@ class GameStateMachine {
             phase = GamePhase.PLAYER_TURN,
             roundNumber = 1,
             deck = createInitialDeck(),
+            players =
+                state.players.map { player ->
+                    player.copy(
+                        animals = emptyList(),
+                        moneyCards = createInitialMoney(player.id),
+                    )
+                },
             currentFaceUpCard = null,
             currentPlayerIndex = 0,
             auctionState = null,
@@ -337,9 +351,7 @@ class GameStateMachine {
 
     private fun finishRound(state: GameState): GameState {
         check(
-            state.phase == GamePhase.AUCTION ||
-                state.phase == GamePhase.TRADE ||
-                state.phase == GamePhase.ROUND_END,
+            state.phase == GamePhase.ROUND_END,
         ) {
             "Cannot finish a round during phase ${state.phase}"
         }
@@ -368,12 +380,30 @@ class GameStateMachine {
 
     private fun createInitialDeck(): AnimalDeck =
         AnimalDeck(
-            listOf(
-                AnimalCard(id = "1", type = AnimalType.COW),
-                AnimalCard(id = "2", type = AnimalType.DOG),
-                AnimalCard(id = "3", type = AnimalType.CAT),
-            ),
+            AnimalType.entries
+                .flatMap { type ->
+                    (1..CARDS_PER_ANIMAL_TYPE).map { copyNumber ->
+                        AnimalCard(
+                            id = "${type.name.lowercase()}-$copyNumber",
+                            type = type,
+                        )
+                    }
+                }.shuffled(),
         )
+
+    private fun createInitialMoney(playerId: String): List<MoneyCard> =
+        buildList {
+            // IDs include the player so money cards remain unique after transfers.
+            repeat(INITIAL_ZERO_MONEY_CARDS) { index ->
+                add(MoneyCard(id = "$playerId-money-0-${index + 1}", value = 0))
+            }
+            repeat(INITIAL_TEN_MONEY_CARDS) { index ->
+                add(MoneyCard(id = "$playerId-money-10-${index + 1}", value = 10))
+            }
+            repeat(INITIAL_FIFTY_MONEY_CARDS) { index ->
+                add(MoneyCard(id = "$playerId-money-50-${index + 1}", value = 50))
+            }
+        }
 
     private fun requireActivePlayer(state: GameState): PlayerState =
         state.players.getOrNull(state.currentPlayerIndex)

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/service/GameStateMachine.kt
@@ -54,6 +54,7 @@ class GameStateMachine {
                 },
             currentFaceUpCard = null,
             currentPlayerIndex = 0,
+            activePlayerId = state.players.firstOrNull()?.id,
             auctionState = null,
             tradeState = null,
         )
@@ -359,6 +360,7 @@ class GameStateMachine {
         if (state.players.isEmpty()) {
             return state.copy(
                 phase = GamePhase.FINISHED,
+                activePlayerId = null,
                 currentFaceUpCard = null,
                 auctionState = null,
                 tradeState = null,
@@ -372,6 +374,7 @@ class GameStateMachine {
             phase = nextPhase,
             roundNumber = state.roundNumber + 1,
             currentPlayerIndex = nextPlayerIndex,
+            activePlayerId = state.players[nextPlayerIndex].id,
             currentFaceUpCard = null,
             auctionState = null,
             tradeState = null,

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
@@ -51,6 +51,7 @@ class GameSessionTest {
         assertEquals(FULL_DECK_SIZE, state.deck.size())
         assertNull(state.currentFaceUpCard)
         assertEquals(0, state.currentPlayerIndex)
+        assertEquals("player-1", state.activePlayerId)
         assertEquals(1, session.gameState.players.size)
         assertEquals(
             "player-1",

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
@@ -2,6 +2,7 @@ package at.aau.kuhhandel.server.model
 
 import at.aau.kuhhandel.server.service.GameCommand
 import at.aau.kuhhandel.server.service.GameStateMachine
+import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.enums.GamePhase
 import at.aau.kuhhandel.shared.model.GameState
 import org.junit.jupiter.api.Test
@@ -16,6 +17,11 @@ import kotlin.test.assertTrue
 import org.mockito.Mockito.`when` as whenever
 
 class GameSessionTest {
+    private companion object {
+        const val CARDS_PER_ANIMAL_TYPE = 4
+        val FULL_DECK_SIZE = AnimalType.entries.size * CARDS_PER_ANIMAL_TYPE
+    }
+
     @Test
     fun test_newSession_isNotStarted() {
         val session = GameSession("12345", "player-1")
@@ -42,7 +48,7 @@ class GameSessionTest {
         val state = session.startGame()
 
         assertEquals(GamePhase.PLAYER_TURN, state.phase)
-        assertEquals(3, state.deck.size())
+        assertEquals(FULL_DECK_SIZE, state.deck.size())
         assertNull(state.currentFaceUpCard)
         assertEquals(0, state.currentPlayerIndex)
         assertEquals(1, session.gameState.players.size)
@@ -62,7 +68,7 @@ class GameSessionTest {
         session.startGame()
 
         assertEquals(GamePhase.PLAYER_TURN, session.gameState.phase)
-        assertEquals(3, session.gameState.deck.size())
+        assertEquals(FULL_DECK_SIZE, session.gameState.deck.size())
         assertNull(session.gameState.currentFaceUpCard)
     }
 
@@ -74,7 +80,7 @@ class GameSessionTest {
         val state = session.revealNextCard()
 
         assertNotNull(state.currentFaceUpCard)
-        assertEquals(2, state.deck.size())
+        assertEquals(FULL_DECK_SIZE - 1, state.deck.size())
         assertEquals(GamePhase.PLAYER_TURN, state.phase)
         assertNull(state.auctionState)
         assertNull(state.tradeState)
@@ -88,7 +94,7 @@ class GameSessionTest {
         session.revealNextCard()
 
         assertNotNull(session.gameState.currentFaceUpCard)
-        assertEquals(2, session.gameState.deck.size())
+        assertEquals(FULL_DECK_SIZE - 1, session.gameState.deck.size())
         assertEquals(GamePhase.PLAYER_TURN, session.gameState.phase)
     }
 
@@ -97,8 +103,9 @@ class GameSessionTest {
         val session = GameSession("12345", "player-1")
         session.startGame()
 
-        session.revealNextCard()
-        session.revealNextCard()
+        repeat(FULL_DECK_SIZE - 1) {
+            session.revealNextCard()
+        }
         val stateAfterLastCard = session.revealNextCard()
 
         assertNotNull(stateAfterLastCard.currentFaceUpCard)
@@ -111,9 +118,9 @@ class GameSessionTest {
         val session = GameSession("12345", "player-1")
         session.startGame()
 
-        session.revealNextCard()
-        session.revealNextCard()
-        session.revealNextCard()
+        repeat(FULL_DECK_SIZE) {
+            session.revealNextCard()
+        }
         val finalState = session.revealNextCard()
 
         assertEquals(GamePhase.FINISHED, finalState.phase)
@@ -131,7 +138,7 @@ class GameSessionTest {
 
         assertEquals(GamePhase.AUCTION, state.phase)
         assertNotNull(state.auctionState)
-        assertEquals(2, state.deck.size())
+        assertEquals(FULL_DECK_SIZE - 1, state.deck.size())
         assertNull(state.currentFaceUpCard)
         assertEquals(GamePhase.AUCTION, session.gameState.phase)
     }
@@ -243,6 +250,8 @@ class GameSessionTest {
         val session = GameSession("12345", "player-1")
         session.startGame()
         session.chooseAuction()
+        session.closeAuction()
+        session.resolveAuction(auctioneerBuysCard = false)
 
         val state = session.finishRound()
 

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
@@ -1,5 +1,6 @@
 package at.aau.kuhhandel.server.service
 
+import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.enums.GamePhase
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
@@ -12,6 +13,11 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class GameServiceTest {
+    private companion object {
+        const val CARDS_PER_ANIMAL_TYPE = 4
+        val FULL_DECK_SIZE = AnimalType.entries.size * CARDS_PER_ANIMAL_TYPE
+    }
+
     private val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
 
     @Test
@@ -64,7 +70,7 @@ class GameServiceTest {
 
         assertNotNull(state)
         assertEquals(GamePhase.PLAYER_TURN, state.phase)
-        assertEquals(3, state.deck.size())
+        assertEquals(FULL_DECK_SIZE, state.deck.size())
         assertNull(state.currentFaceUpCard)
     }
 
@@ -101,7 +107,7 @@ class GameServiceTest {
         assertNotNull(state)
         assertNotNull(state.currentFaceUpCard)
         assertEquals(GamePhase.PLAYER_TURN, state.phase)
-        assertEquals(2, state.deck.size())
+        assertEquals(FULL_DECK_SIZE - 1, state.deck.size())
     }
 
     @Test
@@ -119,9 +125,9 @@ class GameServiceTest {
         val session = service.createGame("player-1")
         service.startGame(session.gameId)
 
-        service.revealNextCard(session.gameId)
-        service.revealNextCard(session.gameId)
-        service.revealNextCard(session.gameId)
+        repeat(FULL_DECK_SIZE) {
+            service.revealNextCard(session.gameId)
+        }
         val finalState = service.revealNextCard(session.gameId)
 
         assertNotNull(finalState)
@@ -140,7 +146,7 @@ class GameServiceTest {
         assertNotNull(state)
         assertEquals(GamePhase.AUCTION, state.phase)
         assertNotNull(state.auctionState)
-        assertEquals(2, state.deck.size())
+        assertEquals(FULL_DECK_SIZE - 1, state.deck.size())
         assertNull(state.currentFaceUpCard)
         assertNotNull(state.auctionState?.timerEndTime)
     }
@@ -294,6 +300,8 @@ class GameServiceTest {
         val session = service.createGame("player-1")
         service.startGame(session.gameId)
         service.chooseAuction(session.gameId)
+        service.closeAuction(session.gameId)
+        service.resolveAuction(session.gameId, auctioneerBuysCard = false)
 
         val state = service.finishRound(session.gameId)
 
@@ -302,6 +310,18 @@ class GameServiceTest {
         assertEquals(2, state.roundNumber)
         assertNull(state.auctionState)
         assertNull(state.tradeState)
+    }
+
+    @Test
+    fun test_finishRound_rejectsBeforeRoundEnd() {
+        val service = GameService(eventPublisher)
+        val session = service.createGame("player-1")
+        service.startGame(session.gameId)
+        service.chooseAuction(session.gameId)
+
+        assertFailsWith<IllegalStateException> {
+            service.finishRound(session.gameId)
+        }
     }
 
     @Test

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
@@ -17,6 +17,12 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class GameStateMachineTest {
+    private companion object {
+        const val CARDS_PER_ANIMAL_TYPE = 4
+        val FULL_DECK_SIZE = AnimalType.entries.size * CARDS_PER_ANIMAL_TYPE
+        val STARTING_MONEY_VALUES = listOf(0, 0, 10, 10, 10, 10, 50)
+    }
+
     private val stateMachine = GameStateMachine()
 
     @Test
@@ -27,11 +33,53 @@ class GameStateMachineTest {
 
         assertEquals(GamePhase.PLAYER_TURN, updatedState.phase)
         assertEquals(1, updatedState.roundNumber)
-        assertEquals(3, updatedState.deck.size())
+        assertEquals(FULL_DECK_SIZE, updatedState.deck.size())
         assertEquals(0, updatedState.currentPlayerIndex)
         assertNull(updatedState.currentFaceUpCard)
         assertNull(updatedState.auctionState)
         assertNull(updatedState.tradeState)
+    }
+
+    @Test
+    fun test_startGame_createsFullAnimalDeck() {
+        val state = GameState(players = listOf(player("player-1")))
+
+        val updatedState = stateMachine.apply(state, GameCommand.StartGame)
+
+        AnimalType.entries.forEach { type ->
+            assertEquals(
+                CARDS_PER_ANIMAL_TYPE,
+                updatedState.deck.cards.count { card -> card.type == type },
+            )
+        }
+        assertEquals(
+            FULL_DECK_SIZE,
+            updatedState.deck.cards
+                .map { card -> card.id }
+                .toSet()
+                .size,
+        )
+    }
+
+    @Test
+    fun test_startGame_dealsStartingMoneyToEveryPlayer() {
+        val state = GameState(players = listOf(player("player-1"), player("player-2")))
+
+        val updatedState = stateMachine.apply(state, GameCommand.StartGame)
+
+        updatedState.players.forEach { player ->
+            assertEquals(STARTING_MONEY_VALUES, player.moneyCards.map { card -> card.value })
+            assertEquals(90, player.totalMoney())
+            assertEquals(emptyList(), player.animals)
+        }
+        assertEquals(
+            updatedState.players.sumOf { player -> player.moneyCards.size },
+            updatedState.players
+                .flatMap { player -> player.moneyCards }
+                .map { card -> card.id }
+                .toSet()
+                .size,
+        )
     }
 
     @Test
@@ -770,6 +818,86 @@ class GameStateMachineTest {
     }
 
     @Test
+    fun test_finishRound_wrapsLastPlayerBackToFirstPlayer() {
+        val state =
+            GameState(
+                phase = GamePhase.ROUND_END,
+                roundNumber = 3,
+                players = listOf(player("player-1"), player("player-2"), player("player-3")),
+                currentPlayerIndex = 2,
+                deck = AnimalDeck(listOf(AnimalCard(id = "next-card", type = AnimalType.DOG))),
+            )
+
+        val updatedState = stateMachine.apply(state, GameCommand.FinishRound)
+
+        assertEquals(GamePhase.PLAYER_TURN, updatedState.phase)
+        assertEquals(4, updatedState.roundNumber)
+        assertEquals(0, updatedState.currentPlayerIndex)
+    }
+
+    @Test
+    fun test_auctionResolutionThenFinishRoundAdvancesToNextPlayableTurn() {
+        val state =
+            GameState(
+                phase = GamePhase.AUCTION,
+                roundNumber = 1,
+                players = listOf(player("player-1"), player("player-2")),
+                currentPlayerIndex = 0,
+                deck = AnimalDeck(listOf(AnimalCard(id = "next-card", type = AnimalType.DOG))),
+                auctionState = auctionFixture(isClosed = true),
+            )
+
+        val roundEndState =
+            stateMachine.apply(
+                state,
+                GameCommand.ResolveAuction(auctioneerBuysCard = false),
+            )
+        val nextTurnState = stateMachine.apply(roundEndState, GameCommand.FinishRound)
+
+        assertEquals(GamePhase.ROUND_END, roundEndState.phase)
+        assertEquals(GamePhase.PLAYER_TURN, nextTurnState.phase)
+        assertEquals(2, nextTurnState.roundNumber)
+        assertEquals(1, nextTurnState.currentPlayerIndex)
+        assertEquals(listOf("auction-card"), nextTurnState.players[0].animals.map { it.id })
+        assertNull(nextTurnState.currentFaceUpCard)
+        assertNull(nextTurnState.auctionState)
+        assertNull(nextTurnState.tradeState)
+    }
+
+    @Test
+    fun test_tradeResolutionThenFinishRoundAdvancesToNextPlayableTurn() {
+        val state =
+            tradeState(
+                offeredMoneyCardIds = listOf("m-10"),
+                offeredMoney = 10,
+            ).copy(
+                deck = AnimalDeck(listOf(AnimalCard(id = "next-card", type = AnimalType.DOG))),
+            )
+
+        val roundEndState =
+            stateMachine.apply(
+                state,
+                GameCommand.RespondToTrade(
+                    respondingPlayerId = "player-2",
+                    acceptsOffer = true,
+                ),
+            )
+        val nextTurnState = stateMachine.apply(roundEndState, GameCommand.FinishRound)
+
+        assertEquals(GamePhase.ROUND_END, roundEndState.phase)
+        assertEquals(GamePhase.PLAYER_TURN, nextTurnState.phase)
+        assertEquals(2, nextTurnState.roundNumber)
+        assertEquals(1, nextTurnState.currentPlayerIndex)
+        assertEquals(
+            listOf("cow-1", "cow-2", "cow-3"),
+            nextTurnState.players[0].animals.map { animal -> animal.id },
+        )
+        assertNull(nextTurnState.currentFaceUpCard)
+        assertNull(nextTurnState.auctionState)
+        assertNull(nextTurnState.tradeState)
+    }
+
+    @Test
     fun test_finishRound_finishesGameWhenDeckIsEmpty() {
         val state =
             GameState(
@@ -805,6 +933,24 @@ class GameStateMachineTest {
     @Test
     fun test_finishRound_rejectsPlayerTurn() {
         val state = GameState(phase = GamePhase.PLAYER_TURN)
+
+        assertFailsWith<IllegalStateException> {
+            stateMachine.apply(state, GameCommand.FinishRound)
+        }
+    }
+
+    @Test
+    fun test_finishRound_rejectsActiveAuction() {
+        val state = activeAuctionState()
+
+        assertFailsWith<IllegalStateException> {
+            stateMachine.apply(state, GameCommand.FinishRound)
+        }
+    }
+
+    @Test
+    fun test_finishRound_rejectsActiveTrade() {
+        val state = tradeState()
 
         assertFailsWith<IllegalStateException> {
             stateMachine.apply(state, GameCommand.FinishRound)

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
@@ -420,6 +420,21 @@ class GameStateMachineTest {
     }
 
     @Test
+    fun test_placeBid_rejectsBidderWithoutEnoughMoney() {
+        val state =
+            activeAuctionState(
+                bidderMoneyCards = listOf(MoneyCard(id = "p2-money-10", value = 10)),
+            )
+
+        assertFailsWith<IllegalArgumentException> {
+            stateMachine.apply(
+                state,
+                GameCommand.PlaceBid(bidderId = "player-2", amount = 20),
+            )
+        }
+    }
+
+    @Test
     fun test_closeAuction_marksAuctionClosed() {
         val state = activeAuctionState()
 
@@ -484,6 +499,11 @@ class GameStateMachineTest {
             listOf(AnimalCard(id = "auction-card", type = AnimalType.COW)),
             updatedState.players[1].animals,
         )
+        assertEquals(listOf("p2-money-50"), updatedState.players[1].moneyCards.map { it.id })
+        assertEquals(
+            listOf("p1-money-10", "p1-money-50", "p2-money-10"),
+            updatedState.players[0].moneyCards.map { it.id },
+        )
         assertNull(updatedState.auctionState)
     }
 
@@ -509,6 +529,11 @@ class GameStateMachineTest {
             listOf(AnimalCard(id = "auction-card", type = AnimalType.COW)),
             updatedState.players[0].animals,
         )
+        assertEquals(listOf("p1-money-50"), updatedState.players[0].moneyCards.map { it.id })
+        assertEquals(
+            listOf("p2-money-10", "p2-money-50", "p1-money-10"),
+            updatedState.players[1].moneyCards.map { it.id },
+        )
         assertNull(updatedState.auctionState)
     }
 
@@ -528,6 +553,28 @@ class GameStateMachineTest {
             updatedState.players[0].animals,
         )
         assertNull(updatedState.auctionState)
+    }
+
+    @Test
+    fun test_resolveAuction_rejectsBuyBackWhenAuctioneerCannotPayHighestBidder() {
+        val state =
+            activeAuctionState(
+                auctionState =
+                    auctionFixture(
+                        highestBid = 10,
+                        highestBidderId = "player-2",
+                        isClosed = true,
+                    ),
+                auctioneerMoneyCards = emptyList(),
+                bidderMoneyCards = listOf(MoneyCard(id = "p2-money-10", value = 10)),
+            )
+
+        assertFailsWith<IllegalArgumentException> {
+            stateMachine.apply(
+                state,
+                GameCommand.ResolveAuction(auctioneerBuysCard = true),
+            )
+        }
     }
 
     @Test
@@ -1404,15 +1451,30 @@ class GameStateMachineTest {
         )
     }
 
-    private fun activeAuctionState(): GameState = activeAuctionState(auctionFixture())
+    private fun activeAuctionState(): GameState =
+        activeAuctionState(
+            auctionState = auctionFixture(),
+        )
 
-    private fun activeAuctionState(auctionState: AuctionState): GameState =
+    private fun activeAuctionState(
+        auctionState: AuctionState = auctionFixture(),
+        auctioneerMoneyCards: List<MoneyCard> =
+            listOf(
+                MoneyCard(id = "p1-money-10", value = 10),
+                MoneyCard(id = "p1-money-50", value = 50),
+            ),
+        bidderMoneyCards: List<MoneyCard> =
+            listOf(
+                MoneyCard(id = "p2-money-10", value = 10),
+                MoneyCard(id = "p2-money-50", value = 50),
+            ),
+    ): GameState =
         GameState(
             phase = GamePhase.AUCTION,
             players =
                 listOf(
-                    player("player-1"),
-                    player("player-2"),
+                    player("player-1", moneyCards = auctioneerMoneyCards),
+                    player("player-2", moneyCards = bidderMoneyCards),
                     player("player-3"),
                 ),
             auctionState = auctionState,

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameStateMachineTest.kt
@@ -35,6 +35,7 @@ class GameStateMachineTest {
         assertEquals(1, updatedState.roundNumber)
         assertEquals(FULL_DECK_SIZE, updatedState.deck.size())
         assertEquals(0, updatedState.currentPlayerIndex)
+        assertEquals("player-1", updatedState.activePlayerId)
         assertNull(updatedState.currentFaceUpCard)
         assertNull(updatedState.auctionState)
         assertNull(updatedState.tradeState)
@@ -812,6 +813,7 @@ class GameStateMachineTest {
         assertEquals(GamePhase.PLAYER_TURN, updatedState.phase)
         assertEquals(2, updatedState.roundNumber)
         assertEquals(1, updatedState.currentPlayerIndex)
+        assertEquals("player-2", updatedState.activePlayerId)
         assertNull(updatedState.currentFaceUpCard)
         assertNull(updatedState.auctionState)
         assertNull(updatedState.tradeState)
@@ -833,6 +835,7 @@ class GameStateMachineTest {
         assertEquals(GamePhase.PLAYER_TURN, updatedState.phase)
         assertEquals(4, updatedState.roundNumber)
         assertEquals(0, updatedState.currentPlayerIndex)
+        assertEquals("player-1", updatedState.activePlayerId)
     }
 
     @Test
@@ -858,6 +861,7 @@ class GameStateMachineTest {
         assertEquals(GamePhase.PLAYER_TURN, nextTurnState.phase)
         assertEquals(2, nextTurnState.roundNumber)
         assertEquals(1, nextTurnState.currentPlayerIndex)
+        assertEquals("player-2", nextTurnState.activePlayerId)
         assertEquals(listOf("auction-card"), nextTurnState.players[0].animals.map { it.id })
         assertNull(nextTurnState.currentFaceUpCard)
         assertNull(nextTurnState.auctionState)
@@ -888,6 +892,7 @@ class GameStateMachineTest {
         assertEquals(GamePhase.PLAYER_TURN, nextTurnState.phase)
         assertEquals(2, nextTurnState.roundNumber)
         assertEquals(1, nextTurnState.currentPlayerIndex)
+        assertEquals("player-2", nextTurnState.activePlayerId)
         assertEquals(
             listOf("cow-1", "cow-2", "cow-3"),
             nextTurnState.players[0].animals.map { animal -> animal.id },

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
@@ -10,6 +10,7 @@ data class GameState(
     val deck: AnimalDeck = AnimalDeck(),
     val currentFaceUpCard: AnimalCard? = null,
     val currentPlayerIndex: Int = 0,
+    val activePlayerId: String? = null,
     val players: List<PlayerState> = emptyList(),
     // Active auction state, null if no auction is running
     val auctionState: AuctionState? = null,

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/GameStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/GameStateTest.kt
@@ -14,6 +14,7 @@ class GameStateTest {
         assertEquals(GamePhase.NOT_STARTED, state.phase)
         assertEquals(0, state.roundNumber)
         assertEquals(0, state.currentPlayerIndex)
+        assertNull(state.activePlayerId)
         assertNull(state.currentFaceUpCard)
         assertTrue(state.players.isEmpty())
         assertTrue(state.deck.isEmpty())
@@ -39,6 +40,7 @@ class GameStateTest {
                 deck = AnimalDeck(listOf(card)),
                 currentFaceUpCard = card,
                 currentPlayerIndex = 1,
+                activePlayerId = "p2",
                 players = emptyList(),
                 auctionState = auctionState,
                 tradeState = tradeState,
@@ -48,6 +50,7 @@ class GameStateTest {
         assertEquals(2, state.roundNumber)
         assertEquals(card, state.currentFaceUpCard)
         assertEquals(1, state.currentPlayerIndex)
+        assertEquals("p2", state.activePlayerId)
         assertEquals(auctionState, state.auctionState)
         assertEquals(tradeState, state.tradeState)
         assertEquals(1, state.deck.size())


### PR DESCRIPTION
**Summary**

This PR extends the prototype round flow so the game can progress with a full animal deck, proper starting money, explicit round endings, and deterministic player advancement.

**Changes**

- Adds full animal deck setup with 4 cards per animal type.
- Deals initial money cards to each player when the game starts.
- Tracks the active player explicitly in the shared game state.
- Advances from `ROUND_END` back to the next `PLAYER_TURN`.
- Resolves auction outcomes by transferring animal ownership and money cards.
- Keeps trade and auction outcomes consistent with the shared `GameState`.
- Updates tests for full deck setup, starting money, round progression, auction resolution, and merge changes from `main`.

**Issues**

Addresses #144: Resolve Prototype Rounds and Advance Match State.