### PR TITLE
feat: migrate deploy pipeline from SSH image transfer to GHCR

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,6 +24,10 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/aausoftwareengineering2/kuhhandel-server
 
 jobs:
   deploy:
@@ -38,6 +42,31 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: server/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:production
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Prepare SSH
         shell: bash
@@ -59,35 +88,20 @@ jobs:
           EOF
           chmod 600 ~/.ssh/config
 
-      - name: Build Docker image
-        shell: bash
-        run: |
-          docker build \
-            --label org.opencontainers.image.revision="${GITHUB_SHA}" \
-            --label org.opencontainers.image.source="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
-            -f server/Dockerfile \
-            -t kuhhandel-server:production \
-            .
-
-      - name: Upload image to server
-        shell: bash
-        run: |
-          docker save kuhhandel-server:production \
-            | gzip \
-            | ssh deploy-target 'gunzip | docker load'
-
       - name: Upload compose file
         shell: bash
         run: |
           ssh deploy-target 'mkdir -p "$HOME/kuhhandel"'
           scp deploy/compose.production.yaml deploy-target:~/kuhhandel/compose.production.yaml
 
-      - name: Restart production service
+      - name: Pull image and restart production service
         shell: bash
         run: |
           ssh deploy-target '
             set -e
-            SERVER_IMAGE=kuhhandel-server:production docker compose --env-file "$HOME/kuhhandel/.env.infra" -f "$HOME/kuhhandel/compose.production.yaml" up -d --remove-orphans
+            cd "$HOME/kuhhandel"
+            docker compose --env-file .env.infra -f compose.production.yaml pull
+            docker compose --env-file .env.infra -f compose.production.yaml up -d --remove-orphans
 
             for attempt in $(seq 1 20); do
               if curl -fsS http://127.0.0.1:18080/health >/dev/null; then
@@ -97,6 +111,6 @@ jobs:
               sleep 3
             done
 
-            SERVER_IMAGE=kuhhandel-server:production docker compose --env-file "$HOME/kuhhandel/.env.infra" -f "$HOME/kuhhandel/compose.production.yaml" logs --tail=200
+            docker compose --env-file .env.infra -f compose.production.yaml logs --tail=200
             exit 1
           '

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -24,6 +24,10 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/aausoftwareengineering2/kuhhandel-server
 
 jobs:
   deploy:
@@ -38,6 +42,31 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: server/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:staging
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Prepare SSH
         shell: bash
@@ -59,35 +88,20 @@ jobs:
           EOF
           chmod 600 ~/.ssh/config
 
-      - name: Build Docker image
-        shell: bash
-        run: |
-          docker build \
-            --label org.opencontainers.image.revision="${GITHUB_SHA}" \
-            --label org.opencontainers.image.source="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
-            -f server/Dockerfile \
-            -t kuhhandel-server:staging \
-            .
-
-      - name: Upload image to server
-        shell: bash
-        run: |
-          docker save kuhhandel-server:staging \
-            | gzip \
-            | ssh deploy-target 'gunzip | docker load'
-
       - name: Upload compose file
         shell: bash
         run: |
           ssh deploy-target 'mkdir -p "$HOME/kuhhandel"'
           scp deploy/compose.staging.yaml deploy-target:~/kuhhandel/compose.staging.yaml
 
-      - name: Restart staging service
+      - name: Pull image and restart staging service
         shell: bash
         run: |
           ssh deploy-target '
             set -e
-            SERVER_IMAGE=kuhhandel-server:staging docker compose --env-file "$HOME/kuhhandel/.env.infra" -f "$HOME/kuhhandel/compose.staging.yaml" up -d --remove-orphans
+            cd "$HOME/kuhhandel"
+            docker compose --env-file .env.infra -f compose.staging.yaml pull
+            docker compose --env-file .env.infra -f compose.staging.yaml up -d --remove-orphans
 
             for attempt in $(seq 1 20); do
               if curl -fsS http://127.0.0.1:18081/health >/dev/null; then
@@ -97,6 +111,6 @@ jobs:
               sleep 3
             done
 
-            SERVER_IMAGE=kuhhandel-server:staging docker compose --env-file "$HOME/kuhhandel/.env.infra" -f "$HOME/kuhhandel/compose.staging.yaml" logs --tail=200
+            docker compose --env-file .env.infra -f compose.staging.yaml logs --tail=200
             exit 1
           '

--- a/deploy/compose.production.yaml
+++ b/deploy/compose.production.yaml
@@ -2,7 +2,7 @@ name: kuhhandel-production
 
 services:
   server:
-    image: ${SERVER_IMAGE:?SERVER_IMAGE is required}
+    image: ghcr.io/aausoftwareengineering2/kuhhandel-server:${SERVER_IMAGE_TAG:-production}
     container_name: kuhhandel-server-production
     restart: unless-stopped
     environment:

--- a/deploy/compose.staging.yaml
+++ b/deploy/compose.staging.yaml
@@ -2,7 +2,7 @@ name: kuhhandel-staging
 
 services:
   server:
-    image: ${SERVER_IMAGE:?SERVER_IMAGE is required}
+    image: ghcr.io/aausoftwareengineering2/kuhhandel-server:${SERVER_IMAGE_TAG:-staging}
     container_name: kuhhandel-server-staging
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Migrates both deploy workflows from `docker save | ssh ... 'docker load'` over to publishing the image to GHCR and pulling it on the server. Already tested on staging (PR #202 → staging), the production-side workflow uses the identical pattern.

## What changes

- **`deploy-staging.yml` / `deploy-production.yml`**: build with `docker/build-push-action@v6`, push to `ghcr.io/aausoftwareengineering2/kuhhandel-server` with two tags per run — a moving `:staging`/`:production` and an immutable `:sha-<commit>` for rollback. GHA build cache enabled.
- **`compose.staging.yaml` / `compose.production.yaml`**: image reference now points to GHCR, with an optional `SERVER_IMAGE_TAG` override (defaults to `staging`/`production`). Allows rollback to a specific sha tag via `SERVER_IMAGE_TAG=sha-… docker compose up -d`.

Closes #176, parent #175.

## Staging verification

Confirmed on the staging host after PR #202 merge:
- Container running with `ghcr.io/aausoftwareengineering2/kuhhandel-server:staging`
- Image size 362 MB (down from 657 MB legacy local)
- Startup 6 s, RestartCount 0, OOMKilled false
- `/health` returns `{"status":"UP"}`
- Postgres connection re-established cleanly

## Setup note (already done for staging)

The GHCR package `kuhhandel-server` is **public** so the deploy host can pull without authentication. Org-level "Public packages allowed" was enabled, then the package itself was set to Public. No PAT or `docker login` on the server.