### PR TITLE
Implement WebSocket heartbeat and enhance session management

### DIFF
--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -1,0 +1,82 @@
+# Server-Side Setup Notes
+
+Notes for the GCE host that fronts the `kuhhandel-server` container. Most of this
+config lives outside the repo (Caddy, Docker host) — this file documents what is
+there and how to evolve it if WebSocket stability becomes an issue again.
+
+## Reverse proxy: Caddy
+
+Caddy runs natively on the host (not in a container), terminates TLS via
+Let's Encrypt, and reverse-proxies to the local container ports. The current
+`/etc/caddy/Caddyfile` is intentionally minimal:
+
+```caddyfile
+api.se-aau.com {
+    reverse_proxy 127.0.0.1:18080
+}
+
+staging-api.se-aau.com {
+    reverse_proxy 127.0.0.1:18081
+}
+```
+
+Caddy handles the `Upgrade: websocket` handshake transparently via the default
+`reverse_proxy`, so no extra directives are required for WebSocket support.
+
+### Optional hardening for long-lived WebSockets
+
+If sporadic `Connection reset` / `Failed to connect` reports come back,
+the following extra directives make Caddy more tolerant of slow Cloudflare-edge
+paths. Apply them only if needed — they are not required for normal operation.
+
+```caddyfile
+staging-api.se-aau.com {
+    reverse_proxy 127.0.0.1:18081 {
+        transport http {
+            keepalive 5m
+            keepalive_idle_conns_per_host 4
+        }
+    }
+}
+```
+
+After editing the Caddyfile, validate and reload (do **not** restart — that drops
+in-flight requests):
+
+```bash
+sudo caddy validate --config /etc/caddy/Caddyfile
+sudo systemctl reload caddy
+```
+
+## Network path
+
+```
+Android client (OkHttp pingInterval 20s)
+  → Cloudflare edge (Anycast IPv4/IPv6, free tier — ~100s WebSocket idle timeout)
+  → Caddy on GCE :443 (Let's Encrypt termination)
+  → Spring Boot container (127.0.0.1:18080 prod, 127.0.0.1:18081 staging)
+  → Postgres container on the shared `kuhhandel-backend` docker network
+```
+
+## Heartbeats / idle handling
+
+Server-side keepalive is configured in code, not on the proxy:
+
+- `WebSocketHeartbeat` sends a WebSocket ping to every open session every 25 s.
+  This both keeps the Cloudflare edge from idling the connection out and lets the
+  server detect dead sessions sooner (sends that throw `IOException` evict the
+  session from `ConnectionRegistry`).
+- `WebSocketConfig.servletServerContainerFactoryBean` raises Tomcat's per-session
+  idle timeout to 5 minutes, so the heartbeat has time to fire before Tomcat itself
+  would close an "idle" socket.
+- `application.yml` `server.tomcat.*` settings keep HTTP keep-alive longer than
+  the edge idle window.
+
+The Android client (`NetworkClientFactory`) already pings every 20 s via OkHttp,
+so the path is symmetric.
+
+## Memory caps
+
+Both compose files cap JVM heap (`-Xmx`) and Docker `mem_limit`. See
+[`deploy/compose.production.yaml`](../deploy/compose.production.yaml) and
+[`deploy/compose.staging.yaml`](../deploy/compose.staging.yaml).

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/ServerApplication.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/ServerApplication.kt
@@ -2,8 +2,10 @@ package at.aau.kuhhandel.server
 
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
+@EnableScheduling
 class ServerApplication
 
 fun main(args: Array<String>) {

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/ConnectionRegistry.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/ConnectionRegistry.kt
@@ -43,6 +43,12 @@ class ConnectionRegistry {
     fun sessionsFor(gameId: String): Set<WebSocketSession> =
         sessionIdsFor(gameId).mapNotNull { sessionBySessionId[it] }.toSet()
 
+    /**
+     * Snapshot of every currently bound session. Used by WebSocketHeartbeat to ping every live
+     * connection without iterating per-game.
+     */
+    fun allSessions(): Collection<WebSocketSession> = sessionBySessionId.values.toList()
+
     fun unbind(sessionId: String) {
         val gameId = gameBySessionId.remove(sessionId)
         playerBySessionId.remove(sessionId)

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/WebSocketConfig.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/WebSocketConfig.kt
@@ -1,10 +1,12 @@
 package at.aau.kuhhandel.server.websocket
 
 import at.aau.kuhhandel.shared.websocket.WebSocketRoutes
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.socket.config.annotation.EnableWebSocket
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean
 
 /**
  * Registers the game WebSocket endpoint and configures handshake rules.
@@ -20,4 +22,15 @@ class WebSocketConfig(
             // Temporary development setting; should be restricted when origins are finalized
             .setAllowedOrigins("*")
     }
+
+    // Cloudflare free tier closes idle WebSockets after ~100s. We send our own pings every 25s
+    // (see WebSocketHeartbeat), but the container's own idle timeout must outlive that — otherwise
+    // Tomcat would close sessions before the heartbeat fires. 5 minutes leaves headroom for slow
+    // clients. setAsyncSendTimeout caps how long a single send may block before being aborted.
+    @Bean
+    fun servletServerContainerFactoryBean(): ServletServerContainerFactoryBean =
+        ServletServerContainerFactoryBean().apply {
+            maxSessionIdleTimeout = 5L * 60L * 1000L
+            setAsyncSendTimeout(10_000L)
+        }
 }

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/WebSocketHeartbeat.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/WebSocketHeartbeat.kt
@@ -1,0 +1,57 @@
+package at.aau.kuhhandel.server.websocket
+
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.PingMessage
+import org.springframework.web.socket.WebSocketSession
+import java.io.IOException
+import java.nio.ByteBuffer
+
+/**
+ * Sends a WebSocket ping frame to every open session every ~25s.
+ *
+ * Why: the path Client → Cloudflare → Caddy → Tomcat has a ~100s idle timeout at the Cloudflare
+ * edge (free tier). The Android client already pings every 20s via OkHttp; this symmetric
+ * server-side ping does two things:
+ *   1. Detects dead sessions earlier (`session.sendMessage` throws on a half-open connection),
+ *      so we can clean them up via ConnectionRegistry instead of waiting for the next user action.
+ *   2. Keeps the edge from closing the connection during a quiet phase of the game.
+ *
+ * Dead sessions are unbound from the registry so subsequent broadcasts do not target them.
+ */
+@Component
+class WebSocketHeartbeat(
+    private val connectionRegistry: ConnectionRegistry,
+) {
+    private val logger = LoggerFactory.getLogger(WebSocketHeartbeat::class.java)
+
+    @Scheduled(fixedDelay = HEARTBEAT_INTERVAL_MS, initialDelay = HEARTBEAT_INTERVAL_MS)
+    fun sendHeartbeats() {
+        connectionRegistry.allSessions().forEach { session ->
+            pingOrEvict(session)
+        }
+    }
+
+    private fun pingOrEvict(session: WebSocketSession) {
+        if (!session.isOpen) {
+            connectionRegistry.unbind(session.id)
+            return
+        }
+        try {
+            synchronized(session) {
+                if (session.isOpen) {
+                    session.sendMessage(PingMessage(EMPTY_PAYLOAD))
+                }
+            }
+        } catch (e: IOException) {
+            logger.debug("Heartbeat failed for session {} — evicting: {}", session.id, e.message)
+            connectionRegistry.unbind(session.id)
+        }
+    }
+
+    companion object {
+        private const val HEARTBEAT_INTERVAL_MS = 25_000L
+        private val EMPTY_PAYLOAD: ByteBuffer = ByteBuffer.allocate(0)
+    }
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -4,3 +4,11 @@ spring:
 
 server:
   port: ${SERVER_PORT:8080}
+  tomcat:
+    # Keep TCP connections alive longer than the Cloudflare edge idle window, so the heartbeat
+    # frames have something to flow through.
+    connection-timeout: 60s
+    keep-alive-timeout: 60s
+    # WebSocket sessions are long-lived; we do not want Tomcat to drop them after the default
+    # 100 HTTP keep-alive requests (the limit is meant for plain HTTP, not upgraded connections).
+    max-keep-alive-requests: -1

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/ConnectionRegistryTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/ConnectionRegistryTest.kt
@@ -112,6 +112,35 @@ class ConnectionRegistryTest {
     }
 
     @Test
+    fun `allSessions returns snapshot of all bound sessions`() {
+        val session1 = mock(WebSocketSession::class.java)
+        whenever(session1.id).thenReturn("session-1")
+        val session2 = mock(WebSocketSession::class.java)
+        whenever(session2.id).thenReturn("session-2")
+
+        registry.bindSession(session1)
+        registry.bindSession(session2)
+
+        assertEquals(setOf(session1, session2), registry.allSessions().toSet())
+    }
+
+    @Test
+    fun `allSessions returns empty when no sessions are bound`() {
+        assertEquals(emptyList<WebSocketSession>(), registry.allSessions().toList())
+    }
+
+    @Test
+    fun `allSessions reflects unbinds`() {
+        val session = mock(WebSocketSession::class.java)
+        whenever(session.id).thenReturn("session-1")
+        registry.bindSession(session)
+
+        registry.unbind(session.id)
+
+        assertEquals(emptyList<WebSocketSession>(), registry.allSessions().toList())
+    }
+
+    @Test
     fun `unbind removes the mapping`() {
         val session1 = mock(WebSocketSession::class.java)
         whenever(session1.id).thenReturn("session-1")

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/WebSocketConfigTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/WebSocketConfigTest.kt
@@ -2,6 +2,8 @@ package at.aau.kuhhandel.server.websocket
 
 import at.aau.kuhhandel.server.service.GameService
 import at.aau.kuhhandel.shared.websocket.WebSocketRoutes
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -37,5 +39,14 @@ class WebSocketConfigTest {
 
         verify(registry).addHandler(handler, WebSocketRoutes.GAME)
         verify(registration).setAllowedOrigins("*")
+    }
+
+    @Test
+    fun `servletServerContainerFactoryBean sets idle and async timeouts`() {
+        val factoryBean = config.servletServerContainerFactoryBean()
+
+        // Idle timeout must outlive Cloudflare's free-tier ~100s WebSocket idle window.
+        assertEquals(5L * 60L * 1000L, factoryBean.maxSessionIdleTimeout)
+        assertNotNull(factoryBean)
     }
 }

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/WebSocketHeartbeatTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/WebSocketHeartbeatTest.kt
@@ -1,0 +1,78 @@
+package at.aau.kuhhandel.server.websocket
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.springframework.web.socket.PingMessage
+import org.springframework.web.socket.WebSocketSession
+import java.io.IOException
+import org.mockito.Mockito.`when` as whenever
+
+class WebSocketHeartbeatTest {
+    private lateinit var registry: ConnectionRegistry
+    private lateinit var heartbeat: WebSocketHeartbeat
+
+    @BeforeEach
+    fun setUp() {
+        registry = ConnectionRegistry()
+        heartbeat = WebSocketHeartbeat(registry)
+    }
+
+    @Test
+    fun `sendHeartbeats pings every open session`() {
+        val session1 = openSession("session-1")
+        val session2 = openSession("session-2")
+        registry.bindSession(session1)
+        registry.bindSession(session2)
+
+        heartbeat.sendHeartbeats()
+
+        verify(session1).sendMessage(any(PingMessage::class.java))
+        verify(session2).sendMessage(any(PingMessage::class.java))
+    }
+
+    @Test
+    fun `sendHeartbeats evicts a closed session without pinging`() {
+        val session = mock(WebSocketSession::class.java)
+        whenever(session.id).thenReturn("session-closed")
+        whenever(session.isOpen).thenReturn(false)
+        registry.bindSession(session)
+
+        heartbeat.sendHeartbeats()
+
+        verify(session, never()).sendMessage(any())
+        assert(registry.sessionFor(session.id) == null) {
+            "Closed session must be evicted from the registry"
+        }
+    }
+
+    @Test
+    fun `sendHeartbeats evicts a session that throws IOException on send`() {
+        val session = openSession("session-broken")
+        whenever(session.sendMessage(any(PingMessage::class.java)))
+            .thenThrow(IOException("broken pipe"))
+        registry.bindSession(session)
+
+        heartbeat.sendHeartbeats()
+
+        assert(registry.sessionFor(session.id) == null) {
+            "Session whose send throws must be evicted from the registry"
+        }
+    }
+
+    @Test
+    fun `sendHeartbeats with no sessions does nothing and does not throw`() {
+        heartbeat.sendHeartbeats()
+        // No exception means pass; nothing to verify on an empty registry.
+    }
+
+    private fun openSession(id: String): WebSocketSession {
+        val session = mock(WebSocketSession::class.java)
+        whenever(session.id).thenReturn(id)
+        whenever(session.isOpen).thenReturn(true)
+        return session
+    }
+}


### PR DESCRIPTION
This pull request introduces robust server-side WebSocket heartbeat handling to improve connection stability, especially when deployed behind Cloudflare and Caddy. It adds a scheduled heartbeat mechanism that pings all open WebSocket sessions, ensures Tomcat and HTTP keep-alive settings are tuned for long-lived connections, and documents the complete server setup and rationale. Comprehensive tests are included to verify the new functionality.

**WebSocket Heartbeat and Connection Stability**

* Added `WebSocketHeartbeat` component, which sends a ping to every open WebSocket session every 25 seconds to detect dead connections early and keep Cloudflare from closing idle connections. Dead sessions are evicted from the registry.
* Exposed a new `allSessions()` method on `ConnectionRegistry` to allow the heartbeat component to efficiently iterate all live sessions.
* Enabled Spring's scheduling support by annotating `ServerApplication` with `@EnableScheduling`.

**WebSocket and HTTP Server Configuration**

* Configured Tomcat's WebSocket session idle timeout to 5 minutes and async send timeout to 10 seconds via a new `servletServerContainerFactoryBean` in `WebSocketConfig`, ensuring the server outlives Cloudflare's idle window.
* Tuned HTTP keep-alive and connection timeouts in `application.yml` to support long-lived WebSocket connections and prevent premature disconnects.

**Documentation and Testing**

* Added detailed server setup notes in `docs/server-setup.md`, including reverse proxy configuration, network path, heartbeat rationale, and memory caps.
* Added and extended tests for the new heartbeat logic, `ConnectionRegistry`'s new method, and WebSocket configuration timeouts to ensure reliability and correctness. [[1]](diffhunk://#diff-7d984bd11986fb97c5152183cb70e55a8a3e692f7ba828f8b8a4431220a47dffR114-R142) [[2]](diffhunk://#diff-56e6da5c5284f2da3c99a413b2bbfaf9e8a0cce5ec9098111ac1843212c8d3eeR43-R51) [[3]](diffhunk://#diff-2fd66fd2c663d0a421707b5c8c400b75c36ff16067621378dccd708a8fc7449bR1-R78)