### PR TITLE
docs: update server setup documentation for k3s deployment and legacy…

### DIFF
--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -1,14 +1,76 @@
 # Server-Side Setup Notes
 
-Notes for the GCE host that fronts the `kuhhandel-server` container. Most of this
-config lives outside the repo (Caddy, Docker host) — this file documents what is
-there and how to evolve it if WebSocket stability becomes an issue again.
+> **Status (as of Sprint 3):** Production and staging now run on the **3-node k3s
+> cluster** — public access via **Cloudflare Tunnel**, database via **Supabase**.
+> There are no open application ports on the nodes anymore.
+>
+> **Authoritative deployment docs:** [`deploy/k8s/README.md`](../deploy/k8s/README.md)
+> (Kubernetes manifests) and the GitOps repo `SE2_Gruppenprojekt_Deploy` (Flux).
+> This file only adds:
+> 1. **App-level WebSocket / idle behaviour** — still current, independent of the host.
+> 2. **Legacy single-host setup (GCE + Caddy + Docker Compose)** — historical
+>    reference only, **no longer** the production path.
 
-## Reverse proxy: Caddy
+## Current network path (k3s)
 
-Caddy runs natively on the host (not in a container), terminates TLS via
-Let's Encrypt, and reverse-proxies to the local container ports. The current
-`/etc/caddy/Caddyfile` is intentionally minimal:
+```
+Android client (OkHttp pingInterval 20s)
+  → Cloudflare edge (Anycast IPv4/IPv6, free tier — ~100s WebSocket idle timeout)
+  → Cloudflare Tunnel (cloudflared pods in k3s — no public app ports on the nodes)
+  → Kubernetes Service  kuhhandel-server.kuhhandel.svc.cluster.local:8080
+  → Spring Boot server pods
+  → Supabase Postgres (sslmode=verify-full, session pooler :5432)
+```
+
+TLS is terminated at the Cloudflare edge (no longer Caddy / Let's Encrypt). The
+public-hostname → service routes are managed in the Cloudflare dashboard; the
+current list lives under "Cloudflare Hostnames" in
+[`deploy/k8s/README.md`](../deploy/k8s/README.md). The public backend health
+check is reachable at `https://k3s-api.se-aau.com/health`.
+
+## Heartbeats / idle handling (current, app-level)
+
+These settings live in the application code and apply on **any** host (k3s as well
+as the old setup):
+
+- `WebSocketHeartbeat` sends a WebSocket ping to every open session every 25 s.
+  This both keeps the Cloudflare edge from idling the connection out and lets the
+  server detect dead sessions sooner (sends that throw `IOException` evict the
+  session from `ConnectionRegistry`).
+- `WebSocketConfig.servletServerContainerFactoryBean` raises Tomcat's per-session
+  idle timeout to 5 minutes, so the heartbeat has time to fire before Tomcat itself
+  would close an "idle" socket.
+- `application.yml` `server.tomcat.*` settings keep HTTP keep-alive longer than
+  the edge idle window.
+- The Android client (`NetworkClientFactory`) already pings every 20 s via OkHttp,
+  so the path is symmetric.
+
+## Memory caps (current, k8s)
+
+The server heap and container memory are capped in the Kubernetes Deployment (no
+longer via Compose `mem_limit`):
+
+- Container: `resources.requests.memory: 384Mi`, `resources.limits.memory: 512Mi`,
+  `resources.limits.cpu: 500m`
+- JVM: `JAVA_TOOL_OPTIONS=-Xmx256m -XX:+UseSerialGC`
+
+See [`deploy/k8s/base/app/deployment.yaml`](../deploy/k8s/base/app/deployment.yaml).
+
+---
+
+## Legacy: GCE host + Caddy + Docker Compose (historical)
+
+> ⚠️ **No longer the production path.** Kept for reference / rollback only; the
+> Compose files under `deploy/` are marked legacy. The active path is the k3s setup
+> described above.
+
+Notes for the old GCE host that fronted the `kuhhandel-server` container. Most of
+this config lived outside the repo (Caddy, Docker host).
+
+### Reverse proxy: Caddy
+
+Caddy ran natively on the host (not in a container), terminated TLS via
+Let's Encrypt, and reverse-proxied to the local container ports:
 
 ```caddyfile
 api.se-aau.com {
@@ -20,14 +82,14 @@ staging-api.se-aau.com {
 }
 ```
 
-Caddy handles the `Upgrade: websocket` handshake transparently via the default
-`reverse_proxy`, so no extra directives are required for WebSocket support.
+Caddy handled the `Upgrade: websocket` handshake transparently via the default
+`reverse_proxy`, so no extra directives were required for WebSocket support.
 
-### Optional hardening for long-lived WebSockets
+#### Optional hardening for long-lived WebSockets
 
-If sporadic `Connection reset` / `Failed to connect` reports come back,
-the following extra directives make Caddy more tolerant of slow Cloudflare-edge
-paths. Apply them only if needed — they are not required for normal operation.
+If sporadic `Connection reset` / `Failed to connect` reports came back, these
+directives made Caddy more tolerant of slow Cloudflare-edge paths (apply only if
+needed):
 
 ```caddyfile
 staging-api.se-aau.com {
@@ -48,35 +110,18 @@ sudo caddy validate --config /etc/caddy/Caddyfile
 sudo systemctl reload caddy
 ```
 
-## Network path
+### Old network path
 
 ```
 Android client (OkHttp pingInterval 20s)
-  → Cloudflare edge (Anycast IPv4/IPv6, free tier — ~100s WebSocket idle timeout)
+  → Cloudflare edge
   → Caddy on GCE :443 (Let's Encrypt termination)
   → Spring Boot container (127.0.0.1:18080 prod, 127.0.0.1:18081 staging)
   → Postgres container on the shared `kuhhandel-backend` docker network
 ```
 
-## Heartbeats / idle handling
+### Old memory caps
 
-Server-side keepalive is configured in code, not on the proxy:
-
-- `WebSocketHeartbeat` sends a WebSocket ping to every open session every 25 s.
-  This both keeps the Cloudflare edge from idling the connection out and lets the
-  server detect dead sessions sooner (sends that throw `IOException` evict the
-  session from `ConnectionRegistry`).
-- `WebSocketConfig.servletServerContainerFactoryBean` raises Tomcat's per-session
-  idle timeout to 5 minutes, so the heartbeat has time to fire before Tomcat itself
-  would close an "idle" socket.
-- `application.yml` `server.tomcat.*` settings keep HTTP keep-alive longer than
-  the edge idle window.
-
-The Android client (`NetworkClientFactory`) already pings every 20 s via OkHttp,
-so the path is symmetric.
-
-## Memory caps
-
-Both compose files cap JVM heap (`-Xmx`) and Docker `mem_limit`. See
+Both Compose files capped JVM heap (`-Xmx`) and Docker `mem_limit` — see
 [`deploy/compose.production.yaml`](../deploy/compose.production.yaml) and
 [`deploy/compose.staging.yaml`](../deploy/compose.staging.yaml).


### PR DESCRIPTION
This pull request updates the `docs/server-setup.md` documentation to reflect the migration from a single-host Docker/Caddy setup to a Kubernetes (k3s) cluster with Cloudflare Tunnel and Supabase. The new documentation clearly distinguishes between the current production setup and the legacy approach, and provides updated details on network paths, WebSocket handling, and resource limits.

**Current production (k3s/Cloudflare) documentation:**

* Added a new section describing the current deployment on a 3-node k3s cluster, with public access via Cloudflare Tunnel and database via Supabase. No open application ports remain on the nodes. Authoritative deployment docs are now in `deploy/k8s/README.md` and the GitOps repo.
* Detailed the current network path, including Cloudflare edge termination, tunnel routing, and backend health checks.
* Documented current application-level WebSocket heartbeat and idle handling, including server and client ping intervals, Tomcat session timeouts, and relevant configuration settings.
* Added documentation for current memory caps, now set in Kubernetes resource requests/limits and JVM options.

**Legacy (GCE/Caddy/Docker Compose) documentation:**

* Moved the old single-host setup to a legacy section, clarifying it is kept for reference only and is no longer the production path. Updated descriptions of reverse proxy, network path, WebSocket handling, and memory caps to past tense and clarified their historical context. [[1]](diffhunk://#diff-92f36b8d2efe603d93f12b1e84c8dabf7aa4c6d98624d13b0b4d0699e997c3ddL3-R73) [[2]](diffhunk://#diff-92f36b8d2efe603d93f12b1e84c8dabf7aa4c6d98624d13b0b4d0699e997c3ddL23-R92) [[3]](diffhunk://#diff-92f36b8d2efe603d93f12b1e84c8dabf7aa4c6d98624d13b0b4d0699e997c3ddL51-R125)