### PR TITLE
feat: implement GameStateView for player-specific game state information

### DIFF
--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/AuctionComponents.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/AuctionComponents.kt
@@ -23,14 +23,14 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import at.aau.kuhhandel.shared.model.AuctionState
-import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.Player
 
 /** Displays the current auction details, including the animal card, timer, and current highest bid. */
 @Composable
 fun AuctionView(
     auction: AuctionState?,
     timerSeconds: Int? = null,
-    players: List<PlayerState> = emptyList(),
+    players: List<Player> = emptyList(),
 ) {
     if (auction == null) return
 

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/FarmComponents.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/components/FarmComponents.kt
@@ -30,12 +30,12 @@ import at.aau.kuhhandel.app.ui.theme.DarkPurple
 import at.aau.kuhhandel.app.ui.theme.PureWhite
 import at.aau.kuhhandel.app.ui.theme.WhitePurple
 import at.aau.kuhhandel.shared.model.MoneyCard
-import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.Player
 
 /** Displays a summary of an opponent's farm, including their name and money card count. */
 @Composable
 fun OtherFarm(
-    player: PlayerState,
+    player: Player,
     farmColor: FarmColor,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -94,7 +94,7 @@ fun OtherFarm(
 /** Renders a grid of all opponents in the game. */
 @Composable
 fun OpponentList(
-    players: List<PlayerState>,
+    players: List<Player>,
     myId: String?,
     onOpponentClick: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -127,7 +127,7 @@ fun OpponentList(
 @Composable
 fun PlayerFarm(
     modifier: Modifier = Modifier,
-    player: PlayerState?,
+    player: Player?,
     isMyTurn: Boolean,
     selectedMoneyCardIds: Set<String> = emptySet(),
     onCardClick: (MoneyCard) -> Unit = {},

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/game/GameScreen.kt
@@ -39,7 +39,7 @@ import at.aau.kuhhandel.shared.enums.GamePhase
 import at.aau.kuhhandel.shared.model.GameEvent
 import at.aau.kuhhandel.shared.model.GameState
 import at.aau.kuhhandel.shared.model.MoneyCard
-import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.Player
 
 @Composable
 fun GameScreen(
@@ -334,7 +334,10 @@ fun GameScreen(
 
         SnackbarHost(
             hostState = snackbarHostState,
-            modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 140.dp),
+            modifier =
+                Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 140.dp),
         )
     }
 }
@@ -344,11 +347,11 @@ fun GameScreen(
 fun GameScreenPreview() {
     val players =
         listOf(
-            PlayerState("1", "Player 1", moneyCards = List(6) { MoneyCard("a$it", 10) }),
-            PlayerState("2", "Player 2", moneyCards = List(3) { MoneyCard("b$it", 10) }),
-            PlayerState("3", "Player 3", moneyCards = List(5) { MoneyCard("c$it", 10) }),
-            PlayerState("4", "Player 4", moneyCards = List(12) { MoneyCard("d$it", 10) }),
-            PlayerState("5", "Me", moneyCards = List(5) { MoneyCard("m$it", 50) }),
+            Player("1", "Player 1", moneyCards = List(6) { MoneyCard("a$it", 10) }),
+            Player("2", "Player 2", moneyCards = List(3) { MoneyCard("b$it", 10) }),
+            Player("3", "Player 3", moneyCards = List(5) { MoneyCard("c$it", 10) }),
+            Player("4", "Player 4", moneyCards = List(12) { MoneyCard("d$it", 10) }),
+            Player("5", "Me", moneyCards = List(5) { MoneyCard("m$it", 50) }),
         )
     val gameState =
         GameState(

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
@@ -5,7 +5,7 @@ import at.aau.kuhhandel.shared.enums.GamePhase
 import at.aau.kuhhandel.shared.model.AnimalCard
 import at.aau.kuhhandel.shared.model.AnimalDeck
 import at.aau.kuhhandel.shared.model.GameState
-import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.Player
 import at.aau.kuhhandel.shared.websocket.CreateGamePayload
 import at.aau.kuhhandel.shared.websocket.ErrorPayload
 import at.aau.kuhhandel.shared.websocket.GameCreatedPayload
@@ -126,7 +126,7 @@ class GameRepositoryTest {
 
     private fun sampleState(
         phase: GamePhase = GamePhase.NOT_STARTED,
-        players: List<PlayerState> = listOf(PlayerState(id = "player-1", name = "Fabio")),
+        players: List<Player> = listOf(Player(id = "player-1", name = "Fabio")),
         currentCard: AnimalCard? = null,
         deckSize: Int = 0,
     ): GameState =

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/GameViewModelTest.kt
@@ -9,7 +9,7 @@ import at.aau.kuhhandel.shared.model.AnimalCard
 import at.aau.kuhhandel.shared.model.AnimalDeck
 import at.aau.kuhhandel.shared.model.AuctionState
 import at.aau.kuhhandel.shared.model.GameState
-import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.Player
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -118,7 +118,7 @@ class GameViewModelTest {
                     gameState =
                         GameState(
                             phase = GamePhase.PLAYER_CHOICE,
-                            players = listOf(PlayerState(id = "me", name = "Me")),
+                            players = listOf(Player(id = "me", name = "Me")),
                             currentPlayerIndex = 0,
                         ),
                 )
@@ -222,7 +222,7 @@ class GameViewModelTest {
                     gameState =
                         GameState(
                             phase = GamePhase.PLAYER_CHOICE,
-                            players = listOf(PlayerState("me", "Me")),
+                            players = listOf(Player("me", "Me")),
                             currentPlayerIndex = 5,
                         ),
                 )
@@ -237,7 +237,7 @@ class GameViewModelTest {
                     gameState =
                         GameState(
                             phase = GamePhase.PLAYER_CHOICE,
-                            players = listOf(PlayerState("me", "Me")),
+                            players = listOf(Player("me", "Me")),
                             currentPlayerIndex = 0,
                         ),
                 )
@@ -277,7 +277,7 @@ class GameViewModelTest {
             repoStateFlow.value =
                 GameRepositoryState(
                     myPlayerId = "me",
-                    gameState = GameState(players = listOf(PlayerState("other", "Other"))),
+                    gameState = GameState(players = listOf(Player("other", "Other"))),
                 )
             advanceUntilIdle()
             assertTrue(
@@ -350,7 +350,7 @@ class GameViewModelTest {
             repoStateFlow.value =
                 GameRepositoryState(
                     myPlayerId = "me",
-                    gameState = GameState(players = listOf(PlayerState("me", "Me"))),
+                    gameState = GameState(players = listOf(Player("me", "Me"))),
                 )
             viewModel.selectTargetPlayer("other")
             advanceUntilIdle()
@@ -407,9 +407,9 @@ class GameViewModelTest {
                             phase = GamePhase.NOT_STARTED,
                             players =
                                 listOf(
-                                    PlayerState("host-id", "Host"),
-                                    PlayerState("p2", "P2"),
-                                    PlayerState("p3", "P3"),
+                                    Player("host-id", "Host"),
+                                    Player("p2", "P2"),
+                                    Player("p3", "P3"),
                                 ),
                             hostPlayerId = "host-id",
                         ),
@@ -427,9 +427,9 @@ class GameViewModelTest {
                             phase = GamePhase.NOT_STARTED,
                             players =
                                 listOf(
-                                    PlayerState("host-id", "Host"),
-                                    PlayerState("p2", "P2"),
-                                    PlayerState("p3", "P3"),
+                                    Player("host-id", "Host"),
+                                    Player("p2", "P2"),
+                                    Player("p3", "P3"),
                                 ),
                             hostPlayerId = "host-id",
                         ),
@@ -447,8 +447,8 @@ class GameViewModelTest {
                             phase = GamePhase.NOT_STARTED,
                             players =
                                 listOf(
-                                    PlayerState("host-id", "Host"),
-                                    PlayerState("p2", "P2"),
+                                    Player("host-id", "Host"),
+                                    Player("p2", "P2"),
                                 ),
                             hostPlayerId = "host-id",
                         ),
@@ -674,7 +674,7 @@ class GameViewModelTest {
             }
 
             val me =
-                PlayerState(
+                Player(
                     id = "me",
                     name = "Me",
                     animals =
@@ -684,7 +684,7 @@ class GameViewModelTest {
                         ),
                 )
             val other =
-                PlayerState(
+                Player(
                     id = "other",
                     name = "Other",
                     animals =
@@ -748,7 +748,7 @@ class GameViewModelTest {
                             auctionCard = AnimalCard("1", AnimalType.COW),
                             timerEndTime = endTime,
                         ),
-                    players = listOf(PlayerState(id = "p1", name = "P1")),
+                    players = listOf(Player(id = "p1", name = "P1")),
                 )
 
             repoStateFlow.value =
@@ -791,7 +791,7 @@ class GameViewModelTest {
                             auctionCard = AnimalCard("1", AnimalType.COW),
                             timerEndTime = endTime,
                         ),
-                    players = listOf(PlayerState(id = "p1", name = "P1")),
+                    players = listOf(Player(id = "p1", name = "P1")),
                 )
 
             repoStateFlow.value =

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/LobbyViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/LobbyViewModelTest.kt
@@ -5,7 +5,7 @@ import at.aau.kuhhandel.app.network.game.GameRepositoryState
 import at.aau.kuhhandel.app.ui.menu.lobby.LobbyViewModel
 import at.aau.kuhhandel.shared.enums.GamePhase
 import at.aau.kuhhandel.shared.model.GameState
-import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.Player
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -89,8 +89,8 @@ class LobbyViewModelTest {
 
             val players =
                 listOf(
-                    PlayerState(id = "p1", name = "Alice"),
-                    PlayerState(id = "p2", name = "Bob"),
+                    Player(id = "p1", name = "Alice"),
+                    Player(id = "p2", name = "Bob"),
                 )
             val gameState = GameState(players = players, phase = GamePhase.NOT_STARTED)
 
@@ -121,7 +121,7 @@ class LobbyViewModelTest {
             // case one, connected with 2 players
             val lobbyState =
                 GameState(
-                    players = listOf(PlayerState("p1", "Alice"), PlayerState("p2", "Bob")),
+                    players = listOf(Player("p1", "Alice"), Player("p2", "Bob")),
                     phase = GamePhase.NOT_STARTED,
                 )
             repoStateFlow.value =
@@ -136,7 +136,7 @@ class LobbyViewModelTest {
             // case two, only 1 player
             val singlePlayerState =
                 GameState(
-                    players = listOf(PlayerState("p1", "Alice")),
+                    players = listOf(Player("p1", "Alice")),
                     phase = GamePhase.NOT_STARTED,
                 )
             repoStateFlow.value =
@@ -151,7 +151,7 @@ class LobbyViewModelTest {
             // Case three, Game already started
             val startedGameState =
                 GameState(
-                    players = listOf(PlayerState("p1", "Alice"), PlayerState("p2", "Bob")),
+                    players = listOf(Player("p1", "Alice"), Player("p2", "Bob")),
                     phase = GamePhase.AUCTION_BIDDING,
                 )
             repoStateFlow.value =

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
@@ -290,11 +290,24 @@ class GameSession(
         ensureTradeInitiatorHasAnimalType(initiator, animalType)
         ensureTradeTargetHasAnimalType(target, animalType)
         ensureOfferNotEmpty(offeredMoneyCardIds)
-        ensureOwnsMoneyCards(initiator, offeredMoneyCardIds)
+        val offeredMoneyCards = requireOwnsMoneyCards(initiator, offeredMoneyCardIds)
+
+        // Remove money cards from the player and update all players
+        val updatedInitiator =
+            initiator.copy(moneyCards = initiator.moneyCards - offeredMoneyCards.toSet())
+        val updatedPlayers =
+            state.players.map { player ->
+                if (player.id == initiator.id) {
+                    updatedInitiator
+                } else {
+                    player
+                }
+            }
 
         state =
             state.copy(
                 phase = GamePhase.TRADE_RESPONSE,
+                players = updatedPlayers,
                 tradeState =
                     TradeState(
                         initiatorId = initiator.id,
@@ -302,6 +315,8 @@ class GameSession(
                         requestedAnimalType = animalType,
                         offeredMoneyCardIds = offeredMoneyCardIds,
                         counterOfferedMoneyCardIds = emptySet(),
+                        initiatorMoneyCards = offeredMoneyCards,
+                        targetMoneyCards = null,
                     ),
             )
 
@@ -309,8 +324,8 @@ class GameSession(
     }
 
     /**
-     * Processes the defender's trade reaction, with empty
-     * [counterOfferedMoneyCardIds] representing blind acceptance.
+     * Adds the trade target's response information to the game state, with
+     * empty [counterOfferedMoneyCardIds] representing blind acceptance.
      */
     fun respondToTrade(
         actorId: String,
@@ -320,73 +335,39 @@ class GameSession(
         ensurePhase(GamePhase.TRADE_RESPONSE)
         ensureTradeTarget(actorId)
 
-        val tradeState = state.tradeState!!
-        val initiator = state.players.find { it.id == tradeState.initiatorId }!!
+        val tradeState =
+            checkNotNull(state.tradeState) {
+                "Missing trade state in response phase"
+            }
         var updatedPlayers = state.players
+        var counterOfferedMoneyCards = emptySet<MoneyCard>()
 
-        val offeredMoneyCards =
-            initiator.moneyCards.filter { it.id in tradeState.offeredMoneyCardIds }
-        var counterOfferedMoneyCards = emptyList<MoneyCard>()
-
-        val winner: Player
-        val loser: Player
-
-        if (counterOfferedMoneyCardIds.isEmpty()) {
-            // The trade target accepts the trade blindly
-            winner = initiator
-            loser = target
-
-            // Process the payment
-            updatedPlayers =
-                transferMoneyCards(updatedPlayers, winner, loser, tradeState.offeredMoneyCardIds)
-        } else {
-            // The trade target makes a counteroffer
+        // If the trade target does not accept the trade blindly
+        if (counterOfferedMoneyCardIds.isNotEmpty()) {
             counterOfferedMoneyCards = requireOwnsMoneyCards(target, counterOfferedMoneyCardIds)
 
-            val initiatorTotal = offeredMoneyCards.sumOf { it.value }
-            val targetTotal = counterOfferedMoneyCards.sumOf { it.value }
-
-            if (initiatorTotal >= targetTotal) {
-                winner = initiator
-                loser = target
-            } else {
-                winner = target
-                loser = initiator
-            }
-
-            // Process the payment
+            // Remove money cards from the player and update all players
+            val updatedTarget =
+                target.copy(moneyCards = target.moneyCards - counterOfferedMoneyCards)
             updatedPlayers =
-                transferMoneyCards(
-                    updatedPlayers,
-                    initiator,
-                    target,
-                    tradeState.offeredMoneyCardIds,
-                )
-            updatedPlayers =
-                transferMoneyCards(
-                    updatedPlayers,
-                    target,
-                    initiator,
-                    counterOfferedMoneyCardIds,
-                )
+                state.players.map { player ->
+                    if (player.id == target.id) {
+                        updatedTarget
+                    } else {
+                        player
+                    }
+                }
         }
 
-        // Move cards of the requested animal type
         state =
             state.copy(
                 phase = GamePhase.TRADE_REVEAL,
-                players =
-                    moveAnimalType(
-                        updatedPlayers,
-                        loser,
-                        winner,
-                        tradeState.requestedAnimalType,
-                    ),
+                players = updatedPlayers,
                 tradeState =
                     tradeState.copy(
-                        offeredMoney = offeredMoneyCards.sumOf { it.value },
                         counterOfferedMoneyCardIds = counterOfferedMoneyCardIds,
                         counterOfferedMoney = counterOfferedMoneyCards.sumOf { it.value },
+                        targetMoneyCards = counterOfferedMoneyCards,
                     ),
             )
 
@@ -394,14 +375,75 @@ class GameSession(
     }
 
     /**
-     * Clears the trade session information and wraps up the visibility sequence.
+     * Handles the trade result and wraps up the visibility sequence.
      */
     fun endTradeReveal(): GameState {
         check(
             state.phase == GamePhase.TRADE_REVEAL,
         ) { "Expected a trade reveal but the current phase is ${state.phase}" }
 
-        state = state.copy(tradeState = null)
+        val tradeState =
+            checkNotNull(state.tradeState) {
+                "Missing trade state in reveal phase"
+            }
+
+        // Exchange the money cards
+        val initiatorMoneyCards = tradeState.initiatorMoneyCards
+        val targetMoneyCards =
+            checkNotNull(tradeState.targetMoneyCards) {
+                "Missing trade counteroffer in reveal phase"
+            }
+
+        val updatedPlayers =
+            state.players.map { player ->
+                when (player.id) {
+                    tradeState.initiatorId ->
+                        player.copy(
+                            moneyCards = player.moneyCards + targetMoneyCards,
+                        )
+
+                    tradeState.targetId ->
+                        player.copy(
+                            moneyCards = player.moneyCards + initiatorMoneyCards,
+                        )
+
+                    else -> player
+                }
+            }
+
+        // Move cards of the requested animal type to the winner
+        val initiatorTotal = initiatorMoneyCards.sumOf { it.value }
+        val targetTotal = targetMoneyCards.sumOf { it.value }
+
+        val (winnerId, loserId) =
+            if (initiatorTotal >= targetTotal) {
+                tradeState.initiatorId to tradeState.targetId
+            } else {
+                tradeState.targetId to tradeState.initiatorId
+            }
+
+        val winner =
+            checkNotNull(updatedPlayers.find { it.id == winnerId }) {
+                "Trade winner missing from game state"
+            }
+        val loser =
+            checkNotNull(updatedPlayers.find { it.id == loserId }) {
+                "Trade loser missing from game state"
+            }
+
+        val finalPlayers =
+            moveAnimalType(
+                updatedPlayers,
+                loser,
+                winner,
+                tradeState.requestedAnimalType,
+            )
+
+        state =
+            state.copy(
+                players = finalPlayers,
+                tradeState = null,
+            )
         state = advanceTurnAndCheckGameEnd()
 
         return state
@@ -603,29 +645,17 @@ class GameSession(
         if (offeredMoneyCardIds.isEmpty()) throw GameException(GameErrorReason.OFFER_EMPTY)
     }
 
-    private fun ensureOwnsMoneyCards(
-        player: Player,
-        moneyCardIds: Set<String>,
-    ) {
-        val moneyCards = player.moneyCards.filter { it.id in moneyCardIds }
-        if (moneyCards.size <
-            moneyCardIds.size
-        ) {
-            throw GameException(GameErrorReason.NOT_OWNED_MONEY_CARDS)
-        }
-    }
-
     private fun requireOwnsMoneyCards(
         player: Player,
         moneyCardIds: Set<String>,
-    ): List<MoneyCard> {
+    ): Set<MoneyCard> {
         val moneyCards = player.moneyCards.filter { it.id in moneyCardIds }
         if (moneyCards.size <
             moneyCardIds.size
         ) {
             throw GameException(GameErrorReason.NOT_OWNED_MONEY_CARDS)
         }
-        return moneyCards
+        return moneyCards.toSet()
     }
 
     /**

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
@@ -10,7 +10,7 @@ import at.aau.kuhhandel.shared.model.AuctionState
 import at.aau.kuhhandel.shared.model.GameEvent
 import at.aau.kuhhandel.shared.model.GameState
 import at.aau.kuhhandel.shared.model.MoneyCard
-import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.Player
 import at.aau.kuhhandel.shared.model.TradeState
 
 /**
@@ -65,7 +65,7 @@ class GameSession(
         ensurePhase(GamePhase.NOT_STARTED)
         ensureRoomNotFull()
 
-        val player = PlayerState(playerId, playerName)
+        val player = Player(playerId, playerName)
 
         state =
             state.copy(
@@ -244,8 +244,8 @@ class GameSession(
         val highestBidder = state.players.find { it.id == highestBidderId }!!
 
         // Determine the card receiver and seller
-        val receiver: PlayerState
-        val seller: PlayerState
+        val receiver: Player
+        val seller: Player
 
         if (auctioneerBuysCard) {
             ensureHasEnoughMoney(actor, auctionState.highestBid)
@@ -328,8 +328,8 @@ class GameSession(
             initiator.moneyCards.filter { it.id in tradeState.offeredMoneyCardIds }
         var counterOfferedMoneyCards = emptyList<MoneyCard>()
 
-        val winner: PlayerState
-        val loser: PlayerState
+        val winner: Player
+        val loser: Player
 
         if (counterOfferedMoneyCardIds.isEmpty()) {
             // The trade target accepts the trade blindly
@@ -480,7 +480,7 @@ class GameSession(
         }
     }
 
-    private fun requireActorInRoom(actorId: String): PlayerState =
+    private fun requireActorInRoom(actorId: String): Player =
         state.players.find { it.id == actorId }
             ?: throw GameException(GameErrorReason.UNKNOWN_ACTOR)
 
@@ -530,7 +530,7 @@ class GameSession(
 
     // Temporary check for Sprint 2; will be replaced with another feature in Sprint 3
     private fun ensureHasEnoughMoney(
-        player: PlayerState,
+        player: Player,
         amount: Int,
     ) {
         if (player.totalMoney() < amount) {
@@ -556,7 +556,7 @@ class GameSession(
         }
     }
 
-    private fun requireValidTradeTarget(playerId: String): PlayerState =
+    private fun requireValidTradeTarget(playerId: String): Player =
         state.players.find { it.id == playerId }
             ?: throw GameException(GameErrorReason.UNKNOWN_TRADE_TARGET)
 
@@ -568,7 +568,7 @@ class GameSession(
     }
 
     private fun ensureTradeInitiatorHasAnimalType(
-        initiator: PlayerState,
+        initiator: Player,
         animalType: AnimalType,
     ) {
         if (initiator.animals.none {
@@ -580,7 +580,7 @@ class GameSession(
     }
 
     private fun ensureTradeTargetHasAnimalType(
-        target: PlayerState,
+        target: Player,
         animalType: AnimalType,
     ) {
         if (target.animals.none {
@@ -604,7 +604,7 @@ class GameSession(
     }
 
     private fun ensureOwnsMoneyCards(
-        player: PlayerState,
+        player: Player,
         moneyCardIds: Set<String>,
     ) {
         val moneyCards = player.moneyCards.filter { it.id in moneyCardIds }
@@ -616,7 +616,7 @@ class GameSession(
     }
 
     private fun requireOwnsMoneyCards(
-        player: PlayerState,
+        player: Player,
         moneyCardIds: Set<String>,
     ): List<MoneyCard> {
         val moneyCards = player.moneyCards.filter { it.id in moneyCardIds }
@@ -632,10 +632,10 @@ class GameSession(
      * Appends an animal card to the given player's collection.
      */
     private fun addAnimalToPlayer(
-        players: List<PlayerState>,
+        players: List<Player>,
         receiverId: String,
         animalCard: AnimalCard,
-    ): List<PlayerState> {
+    ): List<Player> {
         // GameState is immutable, so create an updated player list with the card added to the winner.
         return players.map { player ->
             if (player.id == receiverId) {
@@ -650,7 +650,7 @@ class GameSession(
      * Calculates the mathematically optimal combination of money cards to satisfy a transaction.
      */
     private fun selectMoneyCardsForPayment(
-        player: PlayerState,
+        player: Player,
         amount: Int,
     ): Set<String> {
         check(player.totalMoney() >= amount) {
@@ -701,11 +701,11 @@ class GameSession(
      * Determines whether to move one or two cards based on the counts owned by the players.
      */
     private fun moveAnimalType(
-        players: List<PlayerState>,
-        from: PlayerState,
-        to: PlayerState,
+        players: List<Player>,
+        from: Player,
+        to: Player,
         animalType: AnimalType,
-    ): List<PlayerState> {
+    ): List<Player> {
         val fromMatchingCards = from.animals.filter { it.type == animalType }
         val fromCount = fromMatchingCards.size
         val toCount = to.animals.count { it.type == animalType }
@@ -737,11 +737,11 @@ class GameSession(
      * Transfers designated money cards between two players.
      */
     private fun transferMoneyCards(
-        players: List<PlayerState>,
-        from: PlayerState,
-        to: PlayerState,
+        players: List<Player>,
+        from: Player,
+        to: Player,
         moneyCardIds: Set<String>,
-    ): List<PlayerState> {
+    ): List<Player> {
         if (moneyCardIds.isEmpty()) {
             return players
         }

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
@@ -292,33 +292,25 @@ class GameSession(
         ensureOfferNotEmpty(offeredMoneyCardIds)
         val offeredMoneyCards = requireOwnsMoneyCards(initiator, offeredMoneyCardIds)
 
-        // Remove money cards from the player and update all players
-        val updatedInitiator =
-            initiator.copy(moneyCards = initiator.moneyCards - offeredMoneyCards.toSet())
-        val updatedPlayers =
-            state.players.map { player ->
-                if (player.id == initiator.id) {
-                    updatedInitiator
-                } else {
-                    player
-                }
-            }
-
+        // Remove the money cards from the player, transition
+        // the phase, and store the trade information
         state =
-            state.copy(
-                phase = GamePhase.TRADE_RESPONSE,
-                players = updatedPlayers,
-                tradeState =
-                    TradeState(
-                        initiatorId = initiator.id,
-                        targetId = target.id,
-                        requestedAnimalType = animalType,
-                        offeredMoneyCardIds = offeredMoneyCardIds,
-                        counterOfferedMoneyCardIds = emptySet(),
-                        offeredMoneyCards = offeredMoneyCards,
-                        counterOfferedMoneyCards = null,
-                    ),
-            )
+            state
+                .updatePlayer(initiator.id) { player ->
+                    player.copy(moneyCards = initiator.moneyCards - offeredMoneyCards.toSet())
+                }.copy(
+                    phase = GamePhase.TRADE_RESPONSE,
+                    tradeState =
+                        TradeState(
+                            initiatorId = initiator.id,
+                            targetId = target.id,
+                            requestedAnimalType = animalType,
+                            offeredMoneyCardIds = offeredMoneyCardIds,
+                            counterOfferedMoneyCardIds = emptySet(),
+                            offeredMoneyCards = offeredMoneyCards,
+                            counterOfferedMoneyCards = null,
+                        ),
+                )
 
         return state
     }
@@ -339,30 +331,23 @@ class GameSession(
             checkNotNull(state.tradeState) {
                 "Missing trade state in response phase"
             }
-        var updatedPlayers = state.players
         var counterOfferedMoneyCards = emptySet<MoneyCard>()
 
         // If the trade target does not accept the trade blindly
         if (counterOfferedMoneyCardIds.isNotEmpty()) {
             counterOfferedMoneyCards = requireOwnsMoneyCards(target, counterOfferedMoneyCardIds)
 
-            // Remove money cards from the player and update all players
-            val updatedTarget =
-                target.copy(moneyCards = target.moneyCards - counterOfferedMoneyCards)
-            updatedPlayers =
-                state.players.map { player ->
-                    if (player.id == target.id) {
-                        updatedTarget
-                    } else {
-                        player
-                    }
+            // Remove the money cards from the player
+            state =
+                state.updatePlayer(target.id) { player ->
+                    player.copy(moneyCards = target.moneyCards - counterOfferedMoneyCards)
                 }
         }
 
+        // Transition the phase and update the trade information
         state =
             state.copy(
                 phase = GamePhase.TRADE_REVEAL,
-                players = updatedPlayers,
                 tradeState =
                     tradeState.copy(
                         counterOfferedMoneyCardIds = counterOfferedMoneyCardIds,

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
@@ -315,8 +315,8 @@ class GameSession(
                         requestedAnimalType = animalType,
                         offeredMoneyCardIds = offeredMoneyCardIds,
                         counterOfferedMoneyCardIds = emptySet(),
-                        initiatorMoneyCards = offeredMoneyCards,
-                        targetMoneyCards = null,
+                        offeredMoneyCards = offeredMoneyCards,
+                        counterOfferedMoneyCards = null,
                     ),
             )
 
@@ -367,7 +367,7 @@ class GameSession(
                     tradeState.copy(
                         counterOfferedMoneyCardIds = counterOfferedMoneyCardIds,
                         counterOfferedMoney = counterOfferedMoneyCards.sumOf { it.value },
-                        targetMoneyCards = counterOfferedMoneyCards,
+                        counterOfferedMoneyCards = counterOfferedMoneyCards,
                     ),
             )
 
@@ -388,9 +388,9 @@ class GameSession(
             }
 
         // Exchange the money cards
-        val initiatorMoneyCards = tradeState.initiatorMoneyCards
+        val initiatorMoneyCards = tradeState.offeredMoneyCards
         val targetMoneyCards =
-            checkNotNull(tradeState.targetMoneyCards) {
+            checkNotNull(tradeState.counterOfferedMoneyCards) {
                 "Missing trade counteroffer in reveal phase"
             }
 

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/model/GameSession.kt
@@ -111,7 +111,10 @@ class GameSession(
         ensureDeckNotEmpty()
 
         val (auctionCard, updatedDeck) = state.deck.drawTopCard()
-        val card = auctionCard!!
+        val card =
+            checkNotNull(auctionCard) {
+                "Drawn card is null even though deck was not empty"
+            }
 
         var updatedPlayers = state.players
         var event: GameEvent? = null
@@ -176,15 +179,19 @@ class GameSession(
     ): GameState {
         val actor = requireActorInRoom(actorId)
         ensurePhase(GamePhase.AUCTION_BIDDING)
-        ensureNotAuctioneer(actorId)
+        val auctionState =
+            checkNotNull(state.auctionState) {
+                "Missing auction state in bidding phase"
+            }
+        ensureNotAuctioneer(auctionState, actorId)
         ensureHasEnoughMoney(actor, amount)
-        ensureBidNotTooLow(amount)
+        ensureBidNotTooLow(auctionState, amount)
 
         state =
             state.copy(
                 lastEvent = null,
                 auctionState =
-                    state.auctionState!!.copy(
+                    auctionState.copy(
                         highestBid = amount,
                         highestBidderId = actorId,
                         timerEndTime = System.currentTimeMillis() + 5000,
@@ -198,7 +205,10 @@ class GameSession(
      * Concludes the auction once the bidding timeout ends.
      */
     fun closeAuctionAfterTimeout(): GameState {
-        val auctionState = state.auctionState!!
+        val auctionState =
+            checkNotNull(state.auctionState) {
+                "No auction state to close"
+            }
 
         // Edge case: no one placed a bid
         if (auctionState.highestBidderId == null) {
@@ -236,12 +246,21 @@ class GameSession(
     ): GameState {
         val actor = requireActorInRoom(actorId)
         ensurePhase(GamePhase.AUCTION_RESOLUTION)
-        ensureAuctioneer(actorId)
+        val auctionState =
+            checkNotNull(state.auctionState) {
+                "Missing auction state in resolution phase"
+            }
+        ensureAuctioneer(auctionState, actorId)
 
         // The zero-bid case was handled by closeAuctionAfterTimeout()
-        val auctionState = state.auctionState!!
-        val highestBidderId = auctionState.highestBidderId!!
-        val highestBidder = state.players.find { it.id == highestBidderId }!!
+        val highestBidderId =
+            checkNotNull(auctionState.highestBidderId) {
+                "Missing highest bidder in bidding resolution"
+            }
+        val highestBidder =
+            checkNotNull(state.players.find { it.id == highestBidderId }) {
+                "Highest bidder $highestBidderId not found among players"
+            }
 
         // Determine the card receiver and seller
         val receiver: Player
@@ -325,12 +344,12 @@ class GameSession(
     ): GameState {
         val target = requireActorInRoom(actorId)
         ensurePhase(GamePhase.TRADE_RESPONSE)
-        ensureTradeTarget(actorId)
-
         val tradeState =
             checkNotNull(state.tradeState) {
                 "Missing trade state in response phase"
             }
+        ensureTradeTarget(tradeState, actorId)
+
         var counterOfferedMoneyCards = emptySet<MoneyCard>()
 
         // If the trade target does not accept the trade blindly
@@ -409,11 +428,11 @@ class GameSession(
 
         val winner =
             checkNotNull(updatedPlayers.find { it.id == winnerId }) {
-                "Trade winner missing from game state"
+                "Trade winner $winnerId missing from game state"
             }
         val loser =
             checkNotNull(updatedPlayers.find { it.id == loserId }) {
-                "Trade loser missing from game state"
+                "Trade loser $loserId missing from game state"
             }
 
         val finalPlayers =
@@ -547,10 +566,11 @@ class GameSession(
         if (state.deck.isEmpty()) throw GameException(GameErrorReason.DECK_EMPTY)
     }
 
-    private fun ensureNotAuctioneer(playerId: String) {
-        if (state.auctionState!!.auctioneerId ==
-            playerId
-        ) {
+    private fun ensureNotAuctioneer(
+        auctionState: AuctionState,
+        playerId: String,
+    ) {
+        if (auctionState.auctioneerId == playerId) {
             throw GameException(GameErrorReason.OWN_AUCTION)
         }
     }
@@ -567,16 +587,22 @@ class GameSession(
         }
     }
 
-    private fun ensureBidNotTooLow(amount: Int) {
-        if (state.auctionState!!.highestBid >=
+    private fun ensureBidNotTooLow(
+        auctionState: AuctionState,
+        amount: Int,
+    ) {
+        if (auctionState.highestBid >=
             amount
         ) {
             throw GameException(GameErrorReason.BID_TOO_LOW)
         }
     }
 
-    private fun ensureAuctioneer(playerId: String) {
-        if (state.auctionState!!.auctioneerId !=
+    private fun ensureAuctioneer(
+        auctionState: AuctionState,
+        playerId: String,
+    ) {
+        if (auctionState.auctioneerId !=
             playerId
         ) {
             throw GameException(GameErrorReason.NOT_AUCTIONEER)
@@ -618,10 +644,11 @@ class GameSession(
         }
     }
 
-    private fun ensureTradeTarget(playerId: String) {
-        if (state.tradeState!!.targetId !=
-            playerId
-        ) {
+    private fun ensureTradeTarget(
+        tradeState: TradeState,
+        playerId: String,
+    ) {
+        if (tradeState.targetId != playerId) {
             throw GameException(GameErrorReason.NOT_TRADE_TARGET)
         }
     }

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/persistence/GamePersistenceService.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/persistence/GamePersistenceService.kt
@@ -18,7 +18,7 @@ import at.aau.kuhhandel.server.persistence.repository.PlayerMoneyRepository
 import at.aau.kuhhandel.server.persistence.repository.TradeStateRepository
 import at.aau.kuhhandel.server.persistence.repository.UserRepository
 import at.aau.kuhhandel.shared.model.GameState
-import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.Player
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -142,7 +142,7 @@ class GamePersistenceService(
 
     private fun syncPlayers(
         game: GameEntity,
-        players: List<PlayerState>,
+        players: List<Player>,
     ): Map<String, GamePlayerEntity> {
         val existing = gamePlayerRepository.findByGameOrderBySeatOrderAsc(game)
         // username stores the display name; passwordHash stores the UUID player id
@@ -211,7 +211,7 @@ class GamePersistenceService(
 
     private fun syncPlayerInventories(
         playerEntities: Map<String, GamePlayerEntity>,
-        players: List<PlayerState>,
+        players: List<Player>,
     ) {
         players.forEach { player ->
             val entity =

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/persistence/mapper/GameStateMapper.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/persistence/mapper/GameStateMapper.kt
@@ -8,13 +8,14 @@ import at.aau.kuhhandel.server.persistence.entity.GameStatus
 import at.aau.kuhhandel.server.persistence.entity.PlayerAnimalEntity
 import at.aau.kuhhandel.server.persistence.entity.PlayerMoneyEntity
 import at.aau.kuhhandel.server.persistence.entity.TradeStateEntity
+import at.aau.kuhhandel.server.persistence.mapper.GameStateMapper.expandMoney
 import at.aau.kuhhandel.shared.enums.GamePhase
 import at.aau.kuhhandel.shared.model.AnimalCard
 import at.aau.kuhhandel.shared.model.AnimalDeck
 import at.aau.kuhhandel.shared.model.AuctionState
 import at.aau.kuhhandel.shared.model.GameState
 import at.aau.kuhhandel.shared.model.MoneyCard
-import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.Player
 import at.aau.kuhhandel.shared.model.TradeState
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
@@ -42,6 +43,7 @@ object GameStateMapper {
             GamePhase.TRADE_RESPONSE,
             GamePhase.TRADE_REVEAL,
             -> GameStatus.TRADE
+
             GamePhase.FINISHED -> GameStatus.FINISHED
             GamePhase.NOT_STARTED, GamePhase.PLAYER_CHOICE -> GameStatus.LOBBY
         }
@@ -83,10 +85,10 @@ object GameStateMapper {
         val sortedPlayers = players.sortedBy { it.seatOrder }
         val gameIdString = game.id.toString()
 
-        val playerStates =
+        val domainPlayers =
             sortedPlayers.map { player ->
                 val playerKey = requireNotNull(player.id) { "GamePlayerEntity must be persisted" }
-                PlayerState(
+                Player(
                     id = player.user.passwordHash.ifBlank { player.user.username },
                     name = player.user.username,
                     animals =
@@ -109,7 +111,7 @@ object GameStateMapper {
             if (activeUsername == null) {
                 -1
             } else {
-                playerStates.indexOfFirst { it.name == activeUsername }.let {
+                domainPlayers.indexOfFirst { it.name == activeUsername }.let {
                     if (it ==
                         -1
                     ) {
@@ -139,7 +141,7 @@ object GameStateMapper {
                     gameIdString,
                     entity,
                     sortedPlayers,
-                    playerStates,
+                    domainPlayers,
                 )
             }
         val tradeDto =
@@ -147,7 +149,7 @@ object GameStateMapper {
                 toTradeState(gameIdString, entity, sortedPlayers)
             }
 
-        val phase = toGamePhase(game.status, animalDeck, playerStates)
+        val phase = toGamePhase(game.status, animalDeck, domainPlayers)
 
         val faceUpCard =
             game.faceUpAnimalType?.let { animalType ->
@@ -160,17 +162,17 @@ object GameStateMapper {
             deck = animalDeck,
             currentFaceUpCard = faceUpCard,
             currentPlayerIndex = currentPlayerIndex,
-            players = playerStates,
+            players = domainPlayers,
             auctionState = auctionDto,
             tradeState = tradeDto,
-            hostPlayerId = playerStates.firstOrNull()?.id,
+            hostPlayerId = domainPlayers.firstOrNull()?.id,
         )
     }
 
     private fun toGamePhase(
         status: GameStatus,
         deck: AnimalDeck,
-        players: List<PlayerState>,
+        players: List<Player>,
     ): GamePhase =
         when (status) {
             // On restart mid-auction, return to bidding phase; the auction state is still present.
@@ -217,12 +219,12 @@ object GameStateMapper {
         gameId: String,
         entity: AuctionStateEntity,
         players: List<GamePlayerEntity>,
-        playerStates: List<PlayerState>,
+        domainPlayers: List<Player>,
     ): AuctionState {
         val auctioneerId =
             entity.game.activePlayer?.let { active ->
                 players.firstOrNull { it.user.username == active.username }?.user?.passwordHash
-            } ?: playerStates.firstOrNull()?.id ?: ""
+            } ?: domainPlayers.firstOrNull()?.id ?: ""
         val highestBidderId =
             entity.highestBidder?.let { bidder -> findPlayerIdForPlayer(bidder, players) }
 

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
@@ -149,6 +149,7 @@ class GameWebSocketHandler(
                             gameId = gameId,
                             playerId = playerId,
                             state = result.gameState,
+                            stateView = result.gameState.createViewForPlayer(playerId),
                         ),
                     ),
             ),
@@ -167,7 +168,7 @@ class GameWebSocketHandler(
 
         val state = gameService.startGame(gameId, actorId)
 
-        sendStateUpdate(session, envelope.requestId, state)
+        sendStateUpdate(session, envelope.requestId, state, actorId)
         broadcastStateUpdate(gameId, state, session)
     }
 
@@ -205,6 +206,7 @@ class GameWebSocketHandler(
                         GameJoinedPayload(
                             playerId = playerId,
                             state = state,
+                            stateView = state.createViewForPlayer(playerId),
                         ),
                     ),
             ),
@@ -291,6 +293,7 @@ class GameWebSocketHandler(
                         GameStatePayload.serializer(),
                         GameStatePayload(
                             state = state,
+                            stateView = state.createViewForPlayer(payload.playerId),
                         ),
                     ),
             ),
@@ -309,7 +312,7 @@ class GameWebSocketHandler(
 
         val state = gameService.chooseAuction(gameId, actorId)
 
-        sendStateUpdate(session, envelope.requestId, state)
+        sendStateUpdate(session, envelope.requestId, state, actorId)
         broadcastStateUpdate(gameId, state, session)
     }
 
@@ -333,7 +336,7 @@ class GameWebSocketHandler(
                 payload.moneyCardIds,
             )
 
-        sendStateUpdate(session, envelope.requestId, state)
+        sendStateUpdate(session, envelope.requestId, state, actorId)
         broadcastStateUpdate(gameId, state, session)
     }
 
@@ -355,7 +358,7 @@ class GameWebSocketHandler(
                 payload.counterOfferedMoneyCardIds,
             )
 
-        sendStateUpdate(session, envelope.requestId, state)
+        sendStateUpdate(session, envelope.requestId, state, actorId)
         broadcastStateUpdate(gameId, state, session)
     }
 
@@ -372,7 +375,7 @@ class GameWebSocketHandler(
 
         val state = gameService.placeBid(gameId, actorId, payload.amount)
 
-        sendStateUpdate(session, envelope.requestId, state)
+        sendStateUpdate(session, envelope.requestId, state, actorId)
         broadcastStateUpdate(gameId, state, session)
     }
 
@@ -389,7 +392,7 @@ class GameWebSocketHandler(
 
         val state = gameService.resolveAuction(gameId, actorId, payload.buyBack)
 
-        sendStateUpdate(session, envelope.requestId, state)
+        sendStateUpdate(session, envelope.requestId, state, actorId)
         broadcastStateUpdate(gameId, state, session)
     }
 
@@ -405,7 +408,7 @@ class GameWebSocketHandler(
 
         val state = gameService.finishTradeReveal(gameId, actorId)
 
-        sendStateUpdate(session, envelope.requestId, state)
+        sendStateUpdate(session, envelope.requestId, state, actorId)
         broadcastStateUpdate(gameId, state, session)
     }
 
@@ -467,6 +470,7 @@ class GameWebSocketHandler(
         session: WebSocketSession,
         requestId: String?,
         state: GameState,
+        playerId: String,
     ) {
         send(
             session,
@@ -476,7 +480,10 @@ class GameWebSocketHandler(
                 payload =
                     WebSocketJson.json.encodeToJsonElement(
                         GameStatePayload.serializer(),
-                        GameStatePayload(state),
+                        GameStatePayload(
+                            state = state,
+                            stateView = state.createViewForPlayer(playerId),
+                        ),
                     ),
             ),
         )
@@ -492,27 +499,39 @@ class GameWebSocketHandler(
     ) {
         val sessions = connectionRegistry.sessionsFor(gameId)
 
-        val envelope =
-            WebSocketEnvelope(
-                type = WebSocketType.GAME_STATE_UPDATED,
-                requestId = null,
-                payload =
-                    WebSocketJson.json.encodeToJsonElement(
-                        GameStatePayload.serializer(),
-                        GameStatePayload(state),
-                    ),
-            )
-        val json =
-            WebSocketJson.json.encodeToString(WebSocketEnvelope.serializer(), envelope)
-        val message = TextMessage(json)
-
         sessions.forEach { session ->
-            if (session != ignoredSession) {
+            if (session == ignoredSession) return@forEach
+
+            val playerId = connectionRegistry.playerIdFor(session.id) ?: return@forEach
+
+            try {
+                val envelope =
+                    WebSocketEnvelope(
+                        type = WebSocketType.GAME_STATE_UPDATED,
+                        requestId = null,
+                        payload =
+                            WebSocketJson.json.encodeToJsonElement(
+                                GameStatePayload.serializer(),
+                                GameStatePayload(
+                                    state = state,
+                                    stateView = state.createViewForPlayer(playerId),
+                                ),
+                            ),
+                    )
+                val json =
+                    WebSocketJson.json.encodeToString(WebSocketEnvelope.serializer(), envelope)
+                val message = TextMessage(json)
+
                 synchronized(session) {
                     if (session.isOpen) {
                         session.sendMessage(message)
                     }
                 }
+            } catch (e: Exception) {
+                logger.error(
+                    "State update broadcast failed for session ${session.id} corresponding to player $playerId",
+                    e,
+                )
             }
         }
     }

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
@@ -849,9 +849,9 @@ class GameSessionTest {
         assertEquals("player-1", trade.initiatorId)
         assertEquals("player-2", trade.targetId)
         assertEquals(AnimalType.COW, trade.requestedAnimalType)
-        assertEquals(1, trade.initiatorMoneyCards.size)
-        assertTrue(trade.initiatorMoneyCards.any { it.id == targetCardId })
-        assertNull(trade.targetMoneyCards)
+        assertEquals(1, trade.offeredMoneyCards.size)
+        assertTrue(trade.offeredMoneyCards.any { it.id == targetCardId })
+        assertNull(trade.counterOfferedMoneyCards)
     }
 
     @Test
@@ -1100,10 +1100,10 @@ class GameSessionTest {
         assertNotNull(tradeState.initiatorId, updatedTrade.initiatorId)
         assertEquals(tradeState.targetId, updatedTrade.targetId)
         assertEquals(tradeState.requestedAnimalType, updatedTrade.requestedAnimalType)
-        assertEquals(tradeState.initiatorMoneyCards, updatedTrade.initiatorMoneyCards)
+        assertEquals(tradeState.offeredMoneyCards, updatedTrade.offeredMoneyCards)
 
         // Assert: New trade information is added correctly
-        assertEquals(emptySet(), updatedTrade.targetMoneyCards)
+        assertEquals(emptySet(), updatedTrade.counterOfferedMoneyCards)
     }
 
     @Test
@@ -1153,10 +1153,10 @@ class GameSessionTest {
         assertNotNull(tradeState.initiatorId, updatedTrade.initiatorId)
         assertEquals(tradeState.targetId, updatedTrade.targetId)
         assertEquals(tradeState.requestedAnimalType, updatedTrade.requestedAnimalType)
-        assertEquals(tradeState.initiatorMoneyCards, updatedTrade.initiatorMoneyCards)
+        assertEquals(tradeState.offeredMoneyCards, updatedTrade.offeredMoneyCards)
 
         // Assert: New trade information is added correctly
-        val targetMoneyCards = updatedTrade.targetMoneyCards
+        val targetMoneyCards = updatedTrade.counterOfferedMoneyCards
         assertNotNull(targetMoneyCards)
         assertEquals(1, targetMoneyCards.size)
         assertTrue(targetMoneyCards.any { it.id == targetCardId })
@@ -1257,8 +1257,8 @@ class GameSessionTest {
                 initiatorId = "player-1",
                 targetId = "player-2",
                 requestedAnimalType = AnimalType.COW,
-                initiatorMoneyCards = createDummyMoney("player-1", listOf(10)).toSet(),
-                targetMoneyCards = createDummyMoney("player-2", listOf(10)).toSet(),
+                offeredMoneyCards = createDummyMoney("player-1", listOf(10)).toSet(),
+                counterOfferedMoneyCards = createDummyMoney("player-2", listOf(10)).toSet(),
             )
         val customPlayers =
             listOf(
@@ -1316,8 +1316,8 @@ class GameSessionTest {
                 initiatorId = "player-1",
                 targetId = "player-2",
                 requestedAnimalType = AnimalType.COW,
-                initiatorMoneyCards = createDummyMoney("player-1", listOf(10)).toSet(),
-                targetMoneyCards = createDummyMoney("player-2", listOf(50)).toSet(),
+                offeredMoneyCards = createDummyMoney("player-1", listOf(10)).toSet(),
+                counterOfferedMoneyCards = createDummyMoney("player-2", listOf(50)).toSet(),
             )
         val customPlayers =
             listOf(
@@ -1513,8 +1513,8 @@ class GameSessionTest {
                 initiatorId = "player-1",
                 targetId = "player-2",
                 requestedAnimalType = AnimalType.COW,
-                initiatorMoneyCards = createDummyMoney("player-1", listOf(10)).toSet(),
-                targetMoneyCards = emptySet(),
+                offeredMoneyCards = createDummyMoney("player-1", listOf(10)).toSet(),
+                counterOfferedMoneyCards = emptySet(),
             )
 
         val customPlayers =

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
@@ -10,7 +10,7 @@ import at.aau.kuhhandel.shared.model.AuctionState
 import at.aau.kuhhandel.shared.model.GameEvent
 import at.aau.kuhhandel.shared.model.GameState
 import at.aau.kuhhandel.shared.model.MoneyCard
-import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.Player
 import at.aau.kuhhandel.shared.model.TradeState
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -27,9 +27,9 @@ class GameSessionTest {
             phase = GamePhase.NOT_STARTED,
             players =
                 listOf(
-                    PlayerState(id = "player-1", name = "Player 1"),
-                    PlayerState(id = "player-2", name = "Player 2"),
-                    PlayerState(id = "player-3", name = "Player 3"),
+                    Player(id = "player-1", name = "Player 1"),
+                    Player(id = "player-2", name = "Player 2"),
+                    Player(id = "player-3", name = "Player 3"),
                 ),
             hostPlayerId = "player-1",
         )
@@ -124,8 +124,8 @@ class GameSessionTest {
             baselineState.copy(
                 players =
                     baselineState.players +
-                        PlayerState(id = "player-4", "Player-4") +
-                        PlayerState(id = "player-5", "Player 5"),
+                        Player(id = "player-4", "Player-4") +
+                        Player(id = "player-5", "Player 5"),
             )
 
         val session = GameSession.fromState("game-1", brokenState)
@@ -164,7 +164,7 @@ class GameSessionTest {
         val singlePlayerState =
             GameState(
                 phase = GamePhase.NOT_STARTED,
-                players = listOf(PlayerState(id = "player-1", name = "player-1")),
+                players = listOf(Player(id = "player-1", name = "player-1")),
                 hostPlayerId = "player-1",
             )
         val session = GameSession.fromState("game-1", singlePlayerState)
@@ -261,8 +261,8 @@ class GameSessionTest {
             baselineState.copy(
                 players =
                     listOf(
-                        PlayerState(id = "player-1", name = "Player 1"),
-                        PlayerState(id = "player-2", name = "Player 2"),
+                        Player(id = "player-1", name = "Player 1"),
+                        Player(id = "player-2", name = "Player 2"),
                     ),
             )
         val session = GameSession.fromState("game-1", lowPlayerState)
@@ -631,13 +631,13 @@ class GameSessionTest {
             )
         val initialPlayers =
             listOf(
-                PlayerState(id = "player-1", name = "Player 1", moneyCards = emptyList()),
-                PlayerState(
+                Player(id = "player-1", name = "Player 1", moneyCards = emptyList()),
+                Player(
                     id = "player-2",
                     name = "Player 2",
                     moneyCards = createDummyMoney("player-2", listOf(10, 10)),
                 ),
-                PlayerState(id = "player-3", name = "Player 3"),
+                Player(id = "player-3", name = "Player 3"),
             )
         val resolutionState =
             baselineState.copy(
@@ -679,13 +679,13 @@ class GameSessionTest {
             )
         val initialPlayers =
             listOf(
-                PlayerState(
+                Player(
                     id = "player-1",
                     name = "Player 1",
                     moneyCards = createDummyMoney("player-1", listOf(50)),
                 ),
-                PlayerState(id = "player-2", name = "Player 2", moneyCards = emptyList()),
-                PlayerState(id = "player-3", name = "Player 3"),
+                Player(id = "player-2", name = "Player 2", moneyCards = emptyList()),
+                Player(id = "player-3", name = "Player 3"),
             )
         val resolutionState =
             baselineState.copy(
@@ -774,13 +774,13 @@ class GameSessionTest {
         // Auctioneer only has 10 money, but needs 40 to buy
         val poorAuctioneerPlayers =
             listOf(
-                PlayerState(
+                Player(
                     id = "player-1",
                     name = "Player 1",
                     moneyCards = listOf(MoneyCard("p1-10", 10)),
                 ),
-                PlayerState(id = "player-2", name = "Player 2", moneyCards = emptyList()),
-                PlayerState(id = "player-3", name = "Player 3"),
+                Player(id = "player-2", name = "Player 2", moneyCards = emptyList()),
+                Player(id = "player-3", name = "Player 3"),
             )
         val resolutionState =
             baselineState.copy(
@@ -806,18 +806,18 @@ class GameSessionTest {
 
         val initialPlayers =
             listOf(
-                PlayerState(
+                Player(
                     id = "player-1",
                     name = "Player 1",
                     animals = listOf(AnimalCard("c1", AnimalType.COW)),
                     moneyCards = player1Money,
                 ),
-                PlayerState(
+                Player(
                     id = "player-2",
                     name = "Player 2",
                     animals = listOf(AnimalCard("c2", AnimalType.COW)),
                 ),
-                PlayerState(id = "player-3", name = "Player 3"),
+                Player(id = "player-3", name = "Player 3"),
             )
         val playableState =
             baselineState.copy(
@@ -926,12 +926,12 @@ class GameSessionTest {
         // Player 1 has a PIG instead of a COW
         val customPlayers =
             listOf(
-                PlayerState(
+                Player(
                     id = "player-1",
                     name = "Player 1",
                     animals = listOf(AnimalCard("p1", AnimalType.PIG)),
                 ),
-                PlayerState(
+                Player(
                     id = "player-2",
                     name = "Player 2",
                     animals = listOf(AnimalCard("c1", AnimalType.COW)),
@@ -957,12 +957,12 @@ class GameSessionTest {
         // Player 2 (target) has an empty animal list
         val customPlayers =
             listOf(
-                PlayerState(
+                Player(
                     id = "player-1",
                     name = "Player 1",
                     animals = listOf(AnimalCard("c1", AnimalType.COW)),
                 ),
-                PlayerState(id = "player-2", name = "Player 2", animals = emptyList()),
+                Player(id = "player-2", name = "Player 2", animals = emptyList()),
             )
         val playableState =
             baselineState.copy(
@@ -983,12 +983,12 @@ class GameSessionTest {
     fun `chooseTrade fails if money offer is empty`() {
         val customPlayers =
             listOf(
-                PlayerState(
+                Player(
                     id = "player-1",
                     name = "Player 1",
                     animals = listOf(AnimalCard("c1", AnimalType.COW)),
                 ),
-                PlayerState(
+                Player(
                     id = "player-2",
                     name = "Player 2",
                     animals = listOf(AnimalCard("c2", AnimalType.COW)),
@@ -1018,13 +1018,13 @@ class GameSessionTest {
     fun `chooseTrade fails if initiator does not own the offered money cards`() {
         val customPlayers =
             listOf(
-                PlayerState(
+                Player(
                     id = "player-1",
                     name = "Player 1",
                     animals = listOf(AnimalCard("c1", AnimalType.COW)),
                     moneyCards = createDummyMoney("player-1", listOf(10)),
                 ),
-                PlayerState(
+                Player(
                     id = "player-2",
                     name = "Player 2",
                     animals = listOf(AnimalCard("c2", AnimalType.COW)),
@@ -1064,13 +1064,13 @@ class GameSessionTest {
             )
         val customPlayers =
             listOf(
-                PlayerState(
+                Player(
                     id = "player-1",
                     name = "Player 1",
                     animals = listOf(AnimalCard("c1", AnimalType.COW)),
                     moneyCards = createDummyMoney("player-1", listOf(10)),
                 ),
-                PlayerState(
+                Player(
                     id = "player-2",
                     name = "Player 2",
                     animals = listOf(AnimalCard("c2", AnimalType.COW)),
@@ -1116,13 +1116,13 @@ class GameSessionTest {
             )
         val customPlayers =
             listOf(
-                PlayerState(
+                Player(
                     id = "player-1",
                     name = "Player 1",
                     animals = listOf(AnimalCard("c1", AnimalType.COW)),
                     moneyCards = createDummyMoney("player-1", listOf(10)),
                 ),
-                PlayerState(
+                Player(
                     id = "player-2",
                     name = "Player 2",
                     animals = listOf(AnimalCard("c2", AnimalType.COW)),
@@ -1165,13 +1165,13 @@ class GameSessionTest {
             )
         val customPlayers =
             listOf(
-                PlayerState(
+                Player(
                     id = "player-1",
                     name = "Player 1",
                     animals = listOf(AnimalCard("c1", AnimalType.COW)),
                     moneyCards = createDummyMoney("player-1", listOf(10)),
                 ),
-                PlayerState(
+                Player(
                     id = "player-2",
                     name = "Player 2",
                     animals = listOf(AnimalCard("c2", AnimalType.COW)),
@@ -1258,8 +1258,8 @@ class GameSessionTest {
             )
         val customPlayers =
             listOf(
-                PlayerState(id = "player-1", name = "Player 1"),
-                PlayerState(
+                Player(id = "player-1", name = "Player 1"),
+                Player(
                     id = "player-2",
                     name = "Player 2",
                     moneyCards = createDummyMoney("player-2", listOf(10)),
@@ -1413,13 +1413,13 @@ class GameSessionTest {
         // Let's test: 10, 10, 50. Need to pay 15. Optimal is 10+10=20.
         val initialPlayers =
             listOf(
-                PlayerState(
+                Player(
                     id = "player-1",
                     name = "Player 1",
                     moneyCards = createDummyMoney("player-1", listOf(50, 10, 10)),
                 ),
-                PlayerState(id = "player-2", name = "Player 2", moneyCards = emptyList()),
-                PlayerState(id = "player-3", name = "Player 3"),
+                Player(id = "player-2", name = "Player 2", moneyCards = emptyList()),
+                Player(id = "player-3", name = "Player 3"),
             )
         val auctionState =
             AuctionState(
@@ -1465,20 +1465,20 @@ class GameSessionTest {
 
         val customPlayers =
             listOf(
-                PlayerState(
+                Player(
                     id = "player-1",
                     name = "P1",
                     animals = p1Cows,
                     moneyCards =
                         createDummyMoney("player-1", listOf(10)),
                 ),
-                PlayerState(
+                Player(
                     id = "player-2",
                     name = "P2",
                     animals = p2Cows,
                     moneyCards = emptyList(),
                 ),
-                PlayerState(id = "player-3", name = "P3"),
+                Player(id = "player-3", name = "P3"),
             )
 
         val activeState =

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
@@ -445,6 +445,14 @@ class GameSessionTest {
     }
 
     @Test
+    fun `placeBid throws IllegalStateException if auction state is missing`() {
+        val brokenState = baselineState.copy(phase = GamePhase.AUCTION_BIDDING)
+        val session = GameSession.fromState("game-1", brokenState)
+
+        assertThrows<IllegalStateException> { session.placeBid("player-2", amount = 10) }
+    }
+
+    @Test
     fun `placeBid fails if actor is the auctioneer`() {
         val initialAuction =
             AuctionState(
@@ -619,6 +627,17 @@ class GameSessionTest {
     }
 
     @Test
+    fun `closeAuctionAfterTimeout throws IllegalStateException if auction state is missing`() {
+        val biddingState =
+            baselineState.copy(
+                phase = GamePhase.AUCTION_BIDDING,
+            )
+        val session = GameSession.fromState("game-1", biddingState)
+
+        assertThrows<IllegalStateException> { session.closeAuctionAfterTimeout() }
+    }
+
+    @Test
     fun `resolveAuction functions correctly when auctioneer sells`() {
         // Setup: Player 1 is auctioneer. Player 2 wins with a bid of 20 and has two 10 money cards.
         val targetCard = AnimalCard("cow-1", AnimalType.COW)
@@ -734,6 +753,19 @@ class GameSessionTest {
                 session.resolveAuction("player-1", auctioneerBuysCard = false)
             }
         assertEquals(GameErrorReason.INVALID_PHASE, exception.reason)
+    }
+
+    @Test
+    fun `resolveAuction throws IllegalStateException if auction state is missing`() {
+        val brokenState = baselineState.copy(phase = GamePhase.AUCTION_RESOLUTION)
+        val session = GameSession.fromState("game-1", brokenState)
+
+        assertThrows<IllegalStateException> {
+            session.resolveAuction(
+                "player-1",
+                auctioneerBuysCard = false,
+            )
+        }
     }
 
     @Test
@@ -1190,6 +1222,35 @@ class GameSessionTest {
     }
 
     @Test
+    fun `respondToTrade throws IllegalStateException if trade state is missing`() {
+        val customPlayers =
+            listOf(
+                Player(
+                    id = "player-1",
+                    name = "Player 1",
+                    animals = listOf(AnimalCard("c1", AnimalType.COW)),
+                    moneyCards = createDummyMoney("player-1", listOf(10)),
+                ),
+                Player(
+                    id = "player-2",
+                    name = "Player 2",
+                    animals = listOf(AnimalCard("c2", AnimalType.COW)),
+                    moneyCards = emptyList(),
+                ),
+            )
+        val activeState =
+            baselineState.copy(
+                phase = GamePhase.TRADE_RESPONSE,
+                players = customPlayers,
+            )
+        val session = GameSession.fromState("game-1", activeState)
+
+        assertThrows<IllegalStateException> {
+            session.respondToTrade("player-2", counterOfferedMoneyCardIds = emptySet())
+        }
+    }
+
+    @Test
     fun `respondToTrade fails if actor is not the designated trade target`() {
         val tradeState =
             TradeState(
@@ -1375,6 +1436,93 @@ class GameSessionTest {
         assertThrows<IllegalStateException> {
             session.endTradeReveal()
         }
+    }
+
+    @Test
+    fun `endTradeReveal throws IllegalStateException if trade state is missing`() {
+        val brokenState = baselineState.copy(phase = GamePhase.TRADE_REVEAL)
+        val session = GameSession.fromState("game-1", brokenState)
+
+        assertThrows<IllegalStateException> { session.endTradeReveal() }
+    }
+
+    @Test
+    fun `endTradeReveal throws IllegalStateException if trade counteroffer is missing`() {
+        val tradeState =
+            TradeState(
+                initiatorId = "player-1",
+                targetId = "player-2",
+                requestedAnimalType = AnimalType.COW,
+                offeredMoneyCards = createDummyMoney("player-1", listOf(10)).toSet(),
+            )
+        val brokenState =
+            baselineState.copy(
+                phase = GamePhase.TRADE_REVEAL,
+                tradeState = tradeState,
+            )
+        val session = GameSession.fromState("game-1", brokenState)
+
+        assertThrows<IllegalStateException> { session.endTradeReveal() }
+    }
+
+    @Test
+    fun `endTradeReveal throws IllegalStateException if trade winner is not in player list`() {
+        val tradeState =
+            TradeState(
+                initiatorId = "player-1",
+                targetId = "player-2",
+                requestedAnimalType = AnimalType.COW,
+                offeredMoneyCards = createDummyMoney("player-1", listOf(10)).toSet(),
+                counterOfferedMoneyCards = createDummyMoney("player-2", listOf(50)).toSet(),
+            )
+        val customPlayers =
+            listOf(
+                Player(
+                    id = "player-1",
+                    name = "Player 1",
+                    animals = listOf(AnimalCard("c1", AnimalType.COW)),
+                    moneyCards = emptyList(),
+                ),
+            )
+        val brokenState =
+            baselineState.copy(
+                phase = GamePhase.TRADE_REVEAL,
+                tradeState = tradeState,
+                players = customPlayers,
+            )
+        val session = GameSession.fromState("game-1", brokenState)
+
+        assertThrows<IllegalStateException> { session.endTradeReveal() }
+    }
+
+    @Test
+    fun `endTradeReveal throws IllegalStateException if trade loser is not in player list`() {
+        val tradeState =
+            TradeState(
+                initiatorId = "player-1",
+                targetId = "player-2",
+                requestedAnimalType = AnimalType.COW,
+                offeredMoneyCards = createDummyMoney("player-1", listOf(10)).toSet(),
+                counterOfferedMoneyCards = createDummyMoney("player-2", listOf(50)).toSet(),
+            )
+        val customPlayers =
+            listOf(
+                Player(
+                    id = "player-2",
+                    name = "Player 2",
+                    animals = listOf(AnimalCard("c2", AnimalType.COW)),
+                    moneyCards = emptyList(),
+                ),
+            )
+        val brokenState =
+            baselineState.copy(
+                phase = GamePhase.TRADE_REVEAL,
+                tradeState = tradeState,
+                players = customPlayers,
+            )
+        val session = GameSession.fromState("game-1", brokenState)
+
+        assertThrows<IllegalStateException> { session.endTradeReveal() }
     }
 
     @Test

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/model/GameSessionTest.kt
@@ -837,8 +837,11 @@ class GameSessionTest {
                 offeredMoneyCardIds = setOf(targetCardId),
             )
 
-        // Assert: Phase transition
+        val initiator = updatedState.players.find { it.id == "player-1" }!!
+
+        // Assert: Phase transitions, money cards are taken from initiator
         assertEquals(GamePhase.TRADE_RESPONSE, updatedState.phase)
+        assertTrue(initiator.moneyCards.none { it.id == targetCardId })
 
         // Assert: Trade details are initialized accurately
         val trade = updatedState.tradeState
@@ -846,8 +849,9 @@ class GameSessionTest {
         assertEquals("player-1", trade.initiatorId)
         assertEquals("player-2", trade.targetId)
         assertEquals(AnimalType.COW, trade.requestedAnimalType)
-        assertEquals(setOf(targetCardId), trade.offeredMoneyCardIds)
-        assertTrue(trade.counterOfferedMoneyCardIds.isEmpty())
+        assertEquals(1, trade.initiatorMoneyCards.size)
+        assertTrue(trade.initiatorMoneyCards.any { it.id == targetCardId })
+        assertNull(trade.targetMoneyCards)
     }
 
     @Test
@@ -1051,7 +1055,7 @@ class GameSessionTest {
     }
 
     @Test
-    fun `respondToTrade processes blind acceptance path successfully`() {
+    fun `respondToTrade updates trade information and transitions phase on blind acceptance`() {
         // Setup: Player 1 offers 10 money for a COW. Player 2 accepts blindly.
         val offerCardId = "player-1-10-1"
 
@@ -1089,20 +1093,21 @@ class GameSessionTest {
         val updatedState =
             session.respondToTrade("player-2", counterOfferedMoneyCardIds = emptySet())
 
-        val initiator = updatedState.players.find { it.id == "player-1" }!!
-        val target = updatedState.players.find { it.id == "player-2" }!!
-
-        // Assert: Phase transitions, initiator gets the card, money changes hands
+        // Assert: Phase transitions, initial trade details are not changed
         assertEquals(GamePhase.TRADE_REVEAL, updatedState.phase)
-        assertEquals(2, initiator.animals.size) // Got Player 2's cow
-        assertTrue(target.animals.isEmpty())
-        assertTrue(target.moneyCards.any { it.id == offerCardId })
-        assertEquals(10, updatedState.tradeState?.offeredMoney)
-        assertEquals(0, updatedState.tradeState?.counterOfferedMoney)
+        val updatedTrade = updatedState.tradeState
+        assertNotNull(updatedTrade)
+        assertNotNull(tradeState.initiatorId, updatedTrade.initiatorId)
+        assertEquals(tradeState.targetId, updatedTrade.targetId)
+        assertEquals(tradeState.requestedAnimalType, updatedTrade.requestedAnimalType)
+        assertEquals(tradeState.initiatorMoneyCards, updatedTrade.initiatorMoneyCards)
+
+        // Assert: New trade information is added correctly
+        assertEquals(emptySet(), updatedTrade.targetMoneyCards)
     }
 
     @Test
-    fun `respondToTrade processes counteroffer where initiator wins the tiebreaker`() {
+    fun `respondToTrade updates trade information and transitions phase on counteroffer`() {
         // Rule check: initiator Total >= target Total means initiator wins on ties
         val initiatorCardId = "player-1-10-1"
         val targetCardId = "player-2-10-1"
@@ -1141,62 +1146,20 @@ class GameSessionTest {
         val updatedState =
             session.respondToTrade("player-2", counterOfferedMoneyCardIds = setOf(targetCardId))
 
-        val initiator = updatedState.players.find { it.id == "player-1" }!!
-        val target = updatedState.players.find { it.id == "player-2" }!!
+        // Assert: Phase transitions, initial trade details are not changed
+        assertEquals(GamePhase.TRADE_REVEAL, updatedState.phase)
+        val updatedTrade = updatedState.tradeState
+        assertNotNull(updatedTrade)
+        assertNotNull(tradeState.initiatorId, updatedTrade.initiatorId)
+        assertEquals(tradeState.targetId, updatedTrade.targetId)
+        assertEquals(tradeState.requestedAnimalType, updatedTrade.requestedAnimalType)
+        assertEquals(tradeState.initiatorMoneyCards, updatedTrade.initiatorMoneyCards)
 
-        // Assert: Initiator wins the tiebreaker and takes the card. Both kept both sets of cash.
-        assertEquals(2, initiator.animals.size)
-        assertTrue(target.animals.isEmpty())
-        assertTrue(initiator.moneyCards.any { it.id == targetCardId })
-        assertTrue(target.moneyCards.any { it.id == initiatorCardId })
-    }
-
-    @Test
-    fun `respondToTrade processes counteroffer where target wins with higher value`() {
-        val initiatorCardId = "player-1-10-1"
-        val targetCardId = "player-2-50-1"
-
-        val tradeState =
-            TradeState(
-                initiatorId = "player-1",
-                targetId = "player-2",
-                requestedAnimalType = AnimalType.COW,
-                offeredMoneyCardIds = setOf(initiatorCardId),
-            )
-        val customPlayers =
-            listOf(
-                Player(
-                    id = "player-1",
-                    name = "Player 1",
-                    animals = listOf(AnimalCard("c1", AnimalType.COW)),
-                    moneyCards = createDummyMoney("player-1", listOf(10)),
-                ),
-                Player(
-                    id = "player-2",
-                    name = "Player 2",
-                    animals = listOf(AnimalCard("c2", AnimalType.COW)),
-                    moneyCards = createDummyMoney("player-2", listOf(50)),
-                ),
-            )
-        val activeState =
-            baselineState.copy(
-                phase = GamePhase.TRADE_RESPONSE,
-                tradeState = tradeState,
-                players = customPlayers,
-            )
-        val session = GameSession.fromState("game-1", activeState)
-
-        // Act: Player 2 counters with a 50 card
-        val updatedState =
-            session.respondToTrade("player-2", counterOfferedMoneyCardIds = setOf(targetCardId))
-
-        val initiator = updatedState.players.find { it.id == "player-1" }!!
-        val target = updatedState.players.find { it.id == "player-2" }!!
-
-        // Assert: Target wins (50 > 10) and takes the initiator's card
-        assertTrue(initiator.animals.isEmpty())
-        assertEquals(2, target.animals.size)
-        assertEquals(50, updatedState.tradeState?.counterOfferedMoney)
+        // Assert: New trade information is added correctly
+        val targetMoneyCards = updatedTrade.targetMoneyCards
+        assertNotNull(targetMoneyCards)
+        assertEquals(1, targetMoneyCards.size)
+        assertTrue(targetMoneyCards.any { it.id == targetCardId })
     }
 
     @Test
@@ -1284,27 +1247,117 @@ class GameSessionTest {
     }
 
     @Test
-    fun `endTradeReveal clears trade state and advances turn on happy path`() {
-        // Setup: Game is in the TRADE_REVEAL phase with an active trade state
+    fun `endTradeReveal processes counteroffer where initiator wins the tiebreaker`() {
+        // Rule check: initiator Total >= target Total means initiator wins on ties
+        val initiatorCardId = "player-1-10-1"
+        val targetCardId = "player-2-10-1"
+
         val tradeState =
             TradeState(
                 initiatorId = "player-1",
                 targetId = "player-2",
                 requestedAnimalType = AnimalType.COW,
+                initiatorMoneyCards = createDummyMoney("player-1", listOf(10)).toSet(),
+                targetMoneyCards = createDummyMoney("player-2", listOf(10)).toSet(),
             )
-        val activeRevealState =
+        val customPlayers =
+            listOf(
+                Player(
+                    id = "player-1",
+                    name = "Player 1",
+                    animals = listOf(AnimalCard("c1", AnimalType.COW)),
+                    moneyCards = emptyList(),
+                ),
+                Player(
+                    id = "player-2",
+                    name = "Player 2",
+                    animals = listOf(AnimalCard("c2", AnimalType.COW)),
+                    moneyCards = emptyList(),
+                ),
+            )
+        val activeState =
             baselineState.copy(
                 phase = GamePhase.TRADE_REVEAL,
                 tradeState = tradeState,
+                players = customPlayers,
                 currentPlayerIndex = 0, // It was Player 1's turn
                 roundNumber = 5,
             )
-        val session = GameSession.fromState("game-1", activeRevealState)
+        val session = GameSession.fromState("game-1", activeState)
 
+        // Act: End the trade reveal
         val updatedState = session.endTradeReveal()
+
+        val initiator = updatedState.players.find { it.id == "player-1" }!!
+        val target = updatedState.players.find { it.id == "player-2" }!!
 
         // Assert: Trade state is cleared
         assertNull(updatedState.tradeState)
+
+        // Assert: Initiator wins the tiebreaker and takes the animal, money cards are exchanged
+        assertEquals(2, initiator.animals.size)
+        assertTrue(target.animals.isEmpty())
+        assertTrue(initiator.moneyCards.any { it.id == targetCardId })
+        assertTrue(target.moneyCards.any { it.id == initiatorCardId })
+
+        // Assert: Phase goes back to PLAYER_CHOICE and turn advances to the next player
+        assertEquals(GamePhase.PLAYER_CHOICE, updatedState.phase)
+        assertEquals(1, updatedState.currentPlayerIndex) // Moved to Player 2
+        assertEquals(6, updatedState.roundNumber) // Round incremented
+    }
+
+    @Test
+    fun `endTradeReveal processes counteroffer where target wins with higher value`() {
+        val initiatorCardId = "player-1-10-1"
+        val targetCardId = "player-2-50-1"
+
+        val tradeState =
+            TradeState(
+                initiatorId = "player-1",
+                targetId = "player-2",
+                requestedAnimalType = AnimalType.COW,
+                initiatorMoneyCards = createDummyMoney("player-1", listOf(10)).toSet(),
+                targetMoneyCards = createDummyMoney("player-2", listOf(50)).toSet(),
+            )
+        val customPlayers =
+            listOf(
+                Player(
+                    id = "player-1",
+                    name = "Player 1",
+                    animals = listOf(AnimalCard("c1", AnimalType.COW)),
+                    moneyCards = emptyList(),
+                ),
+                Player(
+                    id = "player-2",
+                    name = "Player 2",
+                    animals = listOf(AnimalCard("c2", AnimalType.COW)),
+                    moneyCards = emptyList(),
+                ),
+            )
+        val activeState =
+            baselineState.copy(
+                phase = GamePhase.TRADE_REVEAL,
+                tradeState = tradeState,
+                players = customPlayers,
+                currentPlayerIndex = 0, // It was Player 1's turn
+                roundNumber = 5,
+            )
+        val session = GameSession.fromState("game-1", activeState)
+
+        // Act: End the trade reveal
+        val updatedState = session.endTradeReveal()
+
+        val initiator = updatedState.players.find { it.id == "player-1" }!!
+        val target = updatedState.players.find { it.id == "player-2" }!!
+
+        // Assert: Trade state is cleared
+        assertNull(updatedState.tradeState)
+
+        // Assert: Target wins (50 > 10) and takes the initiator's animal, money cards are exchanged
+        assertTrue(initiator.animals.isEmpty())
+        assertEquals(2, target.animals.size)
+        assertTrue(initiator.moneyCards.any { it.id == targetCardId })
+        assertTrue(target.moneyCards.any { it.id == initiatorCardId })
 
         // Assert: Phase goes back to PLAYER_CHOICE and turn advances to the next player
         assertEquals(GamePhase.PLAYER_CHOICE, updatedState.phase)
@@ -1460,7 +1513,8 @@ class GameSessionTest {
                 initiatorId = "player-1",
                 targetId = "player-2",
                 requestedAnimalType = AnimalType.COW,
-                offeredMoneyCardIds = setOf("player-1-10-1"),
+                initiatorMoneyCards = createDummyMoney("player-1", listOf(10)).toSet(),
+                targetMoneyCards = emptySet(),
             )
 
         val customPlayers =
@@ -1469,8 +1523,7 @@ class GameSessionTest {
                     id = "player-1",
                     name = "P1",
                     animals = p1Cows,
-                    moneyCards =
-                        createDummyMoney("player-1", listOf(10)),
+                    moneyCards = emptyList(),
                 ),
                 Player(
                     id = "player-2",
@@ -1483,14 +1536,14 @@ class GameSessionTest {
 
         val activeState =
             baselineState.copy(
-                phase = GamePhase.TRADE_RESPONSE,
+                phase = GamePhase.TRADE_REVEAL,
                 tradeState = tradeState,
                 players = customPlayers,
             )
         val session = GameSession.fromState("game-1", activeState)
 
         // Act: Blind acceptance
-        val updatedState = session.respondToTrade("player-2", emptySet())
+        val updatedState = session.endTradeReveal()
 
         val initiator = updatedState.players.find { it.id == "player-1" }!!
         val target = updatedState.players.find { it.id == "player-2" }!!

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/persistence/GamePersistenceServiceTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/persistence/GamePersistenceServiceTest.kt
@@ -16,7 +16,7 @@ import at.aau.kuhhandel.shared.model.AnimalDeck
 import at.aau.kuhhandel.shared.model.AuctionState
 import at.aau.kuhhandel.shared.model.GameState
 import at.aau.kuhhandel.shared.model.MoneyCard
-import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.Player
 import at.aau.kuhhandel.shared.model.TradeState
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -71,7 +71,7 @@ class GamePersistenceServiceTest
                     phase = GamePhase.PLAYER_CHOICE,
                     players =
                         listOf(
-                            PlayerState(
+                            Player(
                                 id = "player-1",
                                 name = "player-1",
                                 animals =
@@ -128,8 +128,8 @@ class GamePersistenceServiceTest
                     phase = GamePhase.AUCTION_BIDDING,
                     players =
                         listOf(
-                            PlayerState(id = "player-1", name = "player-1"),
-                            PlayerState(id = "player-2", name = "player-2"),
+                            Player(id = "player-1", name = "player-1"),
+                            Player(id = "player-2", name = "player-2"),
                         ),
                     currentPlayerIndex = 0,
                     auctionState =
@@ -156,8 +156,8 @@ class GamePersistenceServiceTest
                     phase = GamePhase.AUCTION_BIDDING,
                     players =
                         listOf(
-                            PlayerState(id = "player-1", name = "player-1"),
-                            PlayerState(id = "player-2", name = "player-2"),
+                            Player(id = "player-1", name = "player-1"),
+                            Player(id = "player-2", name = "player-2"),
                         ),
                     currentPlayerIndex = 0,
                     auctionState =
@@ -219,7 +219,7 @@ class GamePersistenceServiceTest
                     phase = GamePhase.TRADE_OFFER,
                     players =
                         listOf(
-                            PlayerState(
+                            Player(
                                 id = "player-1",
                                 name = "player-1",
                                 moneyCards =
@@ -229,7 +229,7 @@ class GamePersistenceServiceTest
                                         MoneyCard("money-3", 10),
                                     ),
                             ),
-                            PlayerState(
+                            Player(
                                 id = "player-2",
                                 name = "player-2",
                                 moneyCards =
@@ -275,7 +275,7 @@ class GamePersistenceServiceTest
             val withAuction =
                 initialLobbyState().copy(
                     phase = GamePhase.AUCTION_BIDDING,
-                    players = listOf(PlayerState(id = "player-1", name = "player-1")),
+                    players = listOf(Player(id = "player-1", name = "player-1")),
                     auctionState =
                         AuctionState(
                             auctionCard = AnimalCard(id = "card-1", type = AnimalType.CAT),
@@ -296,7 +296,7 @@ class GamePersistenceServiceTest
                     phase = GamePhase.TRADE_OFFER,
                     players =
                         listOf(
-                            PlayerState(
+                            Player(
                                 id = "player-1",
                                 name = "player-1",
                                 moneyCards =
@@ -305,7 +305,7 @@ class GamePersistenceServiceTest
                                         MoneyCard(id = "m2", value = 50),
                                     ),
                             ),
-                            PlayerState(
+                            Player(
                                 id = "player-2",
                                 name = "player-2",
                                 moneyCards = listOf(MoneyCard(id = "m3", value = 20)),
@@ -337,7 +337,7 @@ class GamePersistenceServiceTest
                     deck = AnimalDeck(listOf(AnimalCard(id = "1", type = AnimalType.COW))),
                     players =
                         listOf(
-                            PlayerState(
+                            Player(
                                 id = "player-1",
                                 name = "player-1",
                                 animals = listOf(AnimalCard(id = "a1", type = AnimalType.CHICKEN)),
@@ -358,7 +358,7 @@ class GamePersistenceServiceTest
                         ),
                     players =
                         listOf(
-                            PlayerState(
+                            Player(
                                 id = "player-1",
                                 name = "player-1",
                                 animals =
@@ -403,6 +403,6 @@ class GamePersistenceServiceTest
         private fun initialLobbyState(): GameState =
             GameState(
                 phase = GamePhase.NOT_STARTED,
-                players = listOf(PlayerState(id = "player-1", name = "player-1")),
+                players = listOf(Player(id = "player-1", name = "player-1")),
             )
     }

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/service/GameServiceTest.kt
@@ -11,7 +11,7 @@ import at.aau.kuhhandel.shared.enums.GamePhase
 import at.aau.kuhhandel.shared.model.AnimalCard
 import at.aau.kuhhandel.shared.model.AuctionState
 import at.aau.kuhhandel.shared.model.GameState
-import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.Player
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -42,7 +42,7 @@ class GameServiceTest {
     private lateinit var service: GameService
     private val gameStateToReturn =
         GameState(
-            players = listOf(PlayerState("player-1", "Player 1")),
+            players = listOf(Player("player-1", "Player 1")),
             hostPlayerId = "explicit string for testing",
         )
 

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -54,6 +54,16 @@ class GameWebSocketHandlerTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    private val baseState =
+        GameState(
+            players =
+                listOf(
+                    Player("player-1", "Player 1"),
+                    Player("player-2", "Player 2"),
+                ),
+            hostPlayerId = "player-1",
+        )
+
     @BeforeEach
     fun setUp() {
         gameService = mock(GameService::class.java)
@@ -70,10 +80,12 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
-    fun `handleGameStateChanged sends GAME_STATE_UPDATED to all sessions`() {
-        val gameState = GameState(phase = GamePhase.AUCTION_BIDDING)
+    fun `handleGameStateChanged broadcasts GAME_STATE_UPDATED`() {
+        val gameState = baseState.copy(phase = GamePhase.AUCTION_BIDDING)
         val event = GameStateChangedEvent(gameId = "game-1", newState = gameState)
 
+        whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
+        whenever(connectionRegistry.playerIdFor("session-2")).thenReturn("player-2")
         whenever(
             connectionRegistry.sessionsFor("game-1"),
         ).thenReturn(setOf(session1, session2))
@@ -82,9 +94,21 @@ class GameWebSocketHandlerTest {
 
         val response1 = captureResponse(session1)
         assertEquals(WebSocketType.GAME_STATE_UPDATED, response1.type)
+        assertNull(response1.requestId)
+
+        val payload1 = decodePayload(response1, GameStatePayload.serializer())
+
+        assertEquals(gameState, payload1.state)
+        assertEquals(gameState.createViewForPlayer("player-1"), payload1.stateView)
 
         val response2 = captureResponse(session2)
         assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
+        assertNull(response2.requestId)
+
+        val payload2 = decodePayload(response2, GameStatePayload.serializer())
+
+        assertEquals(gameState, payload2.state)
+        assertEquals(gameState.createViewForPlayer("player-2"), payload2.stateView)
     }
 
     @Test
@@ -159,6 +183,7 @@ class GameWebSocketHandlerTest {
 
             assertEquals("game-1", payload.gameId)
             assertEquals(createdSession.state, payload.state)
+            assertEquals(createdSession.state.createViewForPlayer("player-1"), payload.stateView)
         }
 
     @Test
@@ -188,9 +213,10 @@ class GameWebSocketHandlerTest {
         runTest(testDispatcher.scheduler) {
             whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
             whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
+            whenever(connectionRegistry.playerIdFor("session-2")).thenReturn("player-2")
             whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
-            val gameState = GameState(phase = GamePhase.PLAYER_CHOICE)
+            val gameState = baseState.copy(phase = GamePhase.PLAYER_CHOICE)
             whenever(gameService.startGame("game-1", "player-1")).thenReturn(gameState)
 
             sendEnvelope(
@@ -208,6 +234,7 @@ class GameWebSocketHandlerTest {
             val payload1 = decodePayload(response1, GameStatePayload.serializer())
 
             assertEquals(gameState, payload1.state)
+            assertEquals(gameState.createViewForPlayer("player-1"), payload1.stateView)
 
             val response2 = captureResponse(session2)
             assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
@@ -216,6 +243,7 @@ class GameWebSocketHandlerTest {
             val payload2 = decodePayload(response2, GameStatePayload.serializer())
 
             assertEquals(gameState, payload2.state)
+            assertEquals(gameState.createViewForPlayer("player-2"), payload2.stateView)
         }
 
     @Test
@@ -235,11 +263,7 @@ class GameWebSocketHandlerTest {
     @Test
     fun `JOIN_GAME binds game and player, sends GAME_JOINED, and broadcasts GAME_STATE_UPDATED`() =
         runTest(testDispatcher.scheduler) {
-            val state =
-                GameState(
-                    players = listOf(Player("player-1", "Player 1")),
-                    hostPlayerId = "player-1",
-                )
+            val state = baseState
 
             val returnedResult =
                 RoomActionResult(
@@ -249,6 +273,7 @@ class GameWebSocketHandlerTest {
                 )
 
             whenever(connectionRegistry.gameIdFor("session-1")).thenReturn(null)
+            whenever(connectionRegistry.playerIdFor("session-2")).thenReturn("player-2")
             whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
             whenever(
@@ -278,6 +303,7 @@ class GameWebSocketHandlerTest {
 
             assertEquals("player-1", payload1.playerId)
             assertEquals(state, payload1.state)
+            assertEquals(state.createViewForPlayer("player-1"), payload1.stateView)
 
             val response2 = captureResponse(session2)
             assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
@@ -286,6 +312,7 @@ class GameWebSocketHandlerTest {
             val payload2 = decodePayload(response2, GameStatePayload.serializer())
 
             assertEquals(state, payload2.state)
+            assertEquals(state.createViewForPlayer("player-2"), payload2.stateView)
         }
 
     @Test
@@ -337,14 +364,11 @@ class GameWebSocketHandlerTest {
     @Test
     fun `LEAVE_GAME unbinds session, sends GAME_LEFT, and broadcasts GAME_STATE_UPDATED`() =
         runTest(testDispatcher.scheduler) {
-            val returnedState =
-                GameState(
-                    players = listOf(Player("player-2", "Player 2")),
-                    hostPlayerId = "player-2",
-                )
+            val returnedState = baseState
 
             whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
             whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
+            whenever(connectionRegistry.playerIdFor("session-2")).thenReturn("player-2")
             whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session2))
 
             whenever(gameService.leaveGame("game-1", "player-1")).thenReturn(returnedState)
@@ -369,6 +393,7 @@ class GameWebSocketHandlerTest {
             val payload2 = decodePayload(response2, GameStatePayload.serializer())
 
             assertEquals(returnedState, payload2.state)
+            assertEquals(returnedState.createViewForPlayer("player-2"), payload2.stateView)
         }
 
     @Test
@@ -423,6 +448,54 @@ class GameWebSocketHandlerTest {
             )
 
             verify(session1, never()).sendMessage(any())
+        }
+
+    @Test
+    fun `broadcastStateUpdate continues even if one player throws an exception`() =
+        runTest(testDispatcher.scheduler) {
+            val session3 = mock(WebSocketSession::class.java)
+            whenever(session3.id).thenReturn("session-3")
+
+            val returnedState = baseState
+
+            whenever(connectionRegistry.gameIdFor("session-3")).thenReturn("game-1")
+            whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
+            whenever(connectionRegistry.playerIdFor("session-2")).thenReturn("player-2")
+            whenever(connectionRegistry.playerIdFor("session-3")).thenReturn("player-3")
+            whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(
+                setOf(
+                    session1,
+                    session2,
+                    session3,
+                ),
+            )
+
+            // Session 1 is open, but its network stream is broken and throws an error on write
+            whenever(session1.isOpen).thenReturn(true)
+            whenever(
+                session1.sendMessage(any()),
+            ).thenThrow(RuntimeException("Network socket broken"))
+
+            // Session 2 is completely healthy
+            whenever(session2.isOpen).thenReturn(true)
+
+            // Session 2 is completely healthy and represents the acting player
+            whenever(session3.isOpen).thenReturn(true)
+
+            whenever(gameService.leaveGame("game-1", "player-3")).thenReturn(returnedState)
+
+            // Act
+            sendEnvelope(
+                session = session3,
+                type = WebSocketType.LEAVE_GAME,
+                requestId = "req-1",
+            )
+
+            // Assert: Session 1 crashed, but Session 2 still received
+            // the update and session3 received the direct message
+            verify(session1).sendMessage(any())
+            verify(session2).sendMessage(any())
+            verify(session3).sendMessage(any())
         }
 
     @Test
@@ -490,6 +563,7 @@ class GameWebSocketHandlerTest {
             val payload = decodePayload(response, GameStatePayload.serializer())
 
             assertEquals(returnedState, payload.state)
+            assertEquals(returnedState.createViewForPlayer("player-1"), payload.stateView)
         }
 
     @Test
@@ -542,9 +616,10 @@ class GameWebSocketHandlerTest {
         runTest(testDispatcher.scheduler) {
             whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
             whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
+            whenever(connectionRegistry.playerIdFor("session-2")).thenReturn("player-2")
             whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
-            val gameState = GameState(phase = GamePhase.AUCTION_BIDDING)
+            val gameState = baseState.copy(phase = GamePhase.AUCTION_BIDDING)
             whenever(gameService.chooseAuction("game-1", "player-1")).thenReturn(gameState)
 
             sendEnvelope(
@@ -562,6 +637,7 @@ class GameWebSocketHandlerTest {
             val payload1 = decodePayload(response1, GameStatePayload.serializer())
 
             assertEquals(gameState, payload1.state)
+            assertEquals(gameState.createViewForPlayer("player-1"), payload1.stateView)
 
             val response2 = captureResponse(session2)
             assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
@@ -570,6 +646,7 @@ class GameWebSocketHandlerTest {
             val payload2 = decodePayload(response2, GameStatePayload.serializer())
 
             assertEquals(gameState, payload2.state)
+            assertEquals(gameState.createViewForPlayer("player-2"), payload2.stateView)
         }
 
     @Test
@@ -622,16 +699,17 @@ class GameWebSocketHandlerTest {
     }
 
     @Test
-    fun `afterConnectionClosed triggers leave for bound sessions`() =
+    fun `afterConnectionClosed removes player and broadcasts GAME_STATE_UPDATED`() =
         runTest(testDispatcher.scheduler) {
             val returnedState =
                 GameState(
-                    players = listOf(),
-                    hostPlayerId = null,
+                    players = listOf(Player("player-2", "Player 2")),
+                    hostPlayerId = "player-2",
                 )
 
             whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
             whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
+            whenever(connectionRegistry.playerIdFor("session-2")).thenReturn("player-2")
             whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session2))
 
             whenever(gameService.leaveGame("game-1", "player-1")).thenReturn(returnedState)
@@ -646,43 +724,7 @@ class GameWebSocketHandlerTest {
 
             val payload2 = decodePayload(response2, GameStatePayload.serializer())
             assertEquals(returnedState, payload2.state)
-        }
-
-    @Test
-    fun `afterConnectionClosed with multiple sessions handles them correctly`() =
-        runTest(testDispatcher.scheduler) {
-            val sessionA = mock(WebSocketSession::class.java)
-            whenever(sessionA.id).thenReturn("session-A")
-            whenever(sessionA.isOpen).thenReturn(true)
-
-            val sessionB = mock(WebSocketSession::class.java)
-            whenever(sessionB.id).thenReturn("session-B")
-            whenever(sessionB.isOpen).thenReturn(true)
-
-            whenever(connectionRegistry.gameIdFor("session-A")).thenReturn("game-1")
-            whenever(connectionRegistry.playerIdFor("session-A")).thenReturn("player-A")
-
-            whenever(connectionRegistry.gameIdFor("session-B")).thenReturn("game-1")
-            whenever(connectionRegistry.playerIdFor("session-B")).thenReturn("player-B")
-
-            val stateAfterALeaves = GameState(players = listOf(Player("player-B", "Player B")))
-            whenever(gameService.leaveGame("game-1", "player-A")).thenReturn(stateAfterALeaves)
-
-            whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(sessionB))
-
-            // Act: Session A disconnects
-            handler.afterConnectionClosed(sessionA, CloseStatus.NORMAL)
-
-            // Assert: A is removed, B gets updated state
-            verify(gameService).leaveGame("game-1", "player-A")
-            verify(connectionRegistry).unbind("session-A")
-
-            val responseB = captureResponse(sessionB)
-            assertEquals(WebSocketType.GAME_STATE_UPDATED, responseB.type)
-            assertEquals(
-                stateAfterALeaves,
-                decodePayload(responseB, GameStatePayload.serializer()).state,
-            )
+            assertEquals(returnedState.createViewForPlayer("player-2"), payload2.stateView)
         }
 
     @Test
@@ -690,9 +732,10 @@ class GameWebSocketHandlerTest {
         runTest(testDispatcher.scheduler) {
             whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
             whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
+            whenever(connectionRegistry.playerIdFor("session-2")).thenReturn("player-2")
             whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
-            val gameState = GameState(phase = GamePhase.TRADE_OFFER)
+            val gameState = baseState.copy(phase = GamePhase.TRADE_OFFER)
             whenever(
                 gameService.chooseTrade(
                     "game-1",
@@ -733,6 +776,7 @@ class GameWebSocketHandlerTest {
             val payload1 = decodePayload(response1, GameStatePayload.serializer())
 
             assertEquals(gameState, payload1.state)
+            assertEquals(gameState.createViewForPlayer("player-1"), payload1.stateView)
 
             val response2 = captureResponse(session2)
             assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
@@ -741,6 +785,7 @@ class GameWebSocketHandlerTest {
             val payload2 = decodePayload(response2, GameStatePayload.serializer())
 
             assertEquals(gameState, payload2.state)
+            assertEquals(gameState.createViewForPlayer("player-2"), payload2.stateView)
         }
 
     @Test
@@ -803,13 +848,13 @@ class GameWebSocketHandlerTest {
     fun `RESPOND_TO_TRADE sends and broadcasts GAME_STATE_UPDATED`() =
         runTest(testDispatcher.scheduler) {
             whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
-            whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-2")
+            whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
+            whenever(connectionRegistry.playerIdFor("session-2")).thenReturn("player-2")
             whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
-            val gameState = GameState(phase = GamePhase.TRADE_REVEAL)
-            whenever(gameService.respondToTrade("game-1", "player-2", emptySet())).thenReturn(
-                gameState,
-            )
+            val gameState = baseState.copy(phase = GamePhase.TRADE_REVEAL)
+            whenever(gameService.respondToTrade("game-1", "player-1", emptySet()))
+                .thenReturn(gameState)
 
             sendEnvelope(
                 session = session1,
@@ -819,13 +864,13 @@ class GameWebSocketHandlerTest {
                     WebSocketJson.json.encodeToJsonElement(
                         RespondToTradePayload.serializer(),
                         RespondToTradePayload(
-                            respondingPlayerId = "player-2",
+                            respondingPlayerId = "player-1",
                             counterOfferedMoneyCardIds = emptySet(),
                         ),
                     ),
             )
 
-            verify(gameService).respondToTrade("game-1", "player-2", emptySet())
+            verify(gameService).respondToTrade("game-1", "player-1", emptySet())
 
             val response1 = captureResponse(session1)
             assertEquals(WebSocketType.GAME_STATE_UPDATED, response1.type)
@@ -834,6 +879,7 @@ class GameWebSocketHandlerTest {
             val payload1 = decodePayload(response1, GameStatePayload.serializer())
 
             assertEquals(gameState, payload1.state)
+            assertEquals(gameState.createViewForPlayer("player-1"), payload1.stateView)
 
             val response2 = captureResponse(session2)
             assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
@@ -842,6 +888,7 @@ class GameWebSocketHandlerTest {
             val payload2 = decodePayload(response2, GameStatePayload.serializer())
 
             assertEquals(gameState, payload2.state)
+            assertEquals(gameState.createViewForPlayer("player-2"), payload2.stateView)
         }
 
     @Test
@@ -904,9 +951,10 @@ class GameWebSocketHandlerTest {
         runTest(testDispatcher.scheduler) {
             whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
             whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
+            whenever(connectionRegistry.playerIdFor("session-2")).thenReturn("player-2")
             whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
-            val gameState = GameState(phase = GamePhase.AUCTION_BIDDING)
+            val gameState = baseState.copy(phase = GamePhase.AUCTION_BIDDING)
             whenever(gameService.placeBid("game-1", "player-1", 100)).thenReturn(gameState)
 
             sendEnvelope(
@@ -929,6 +977,7 @@ class GameWebSocketHandlerTest {
             val payload1 = decodePayload(response1, GameStatePayload.serializer())
 
             assertEquals(gameState, payload1.state)
+            assertEquals(gameState.createViewForPlayer("player-1"), payload1.stateView)
 
             val response2 = captureResponse(session2)
             assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
@@ -937,6 +986,7 @@ class GameWebSocketHandlerTest {
             val payload2 = decodePayload(response2, GameStatePayload.serializer())
 
             assertEquals(gameState, payload2.state)
+            assertEquals(gameState.createViewForPlayer("player-2"), payload2.stateView)
         }
 
     @Test
@@ -1014,9 +1064,10 @@ class GameWebSocketHandlerTest {
         runTest(testDispatcher.scheduler) {
             whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
             whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
+            whenever(connectionRegistry.playerIdFor("session-2")).thenReturn("player-2")
             whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
-            val gameState = GameState(phase = GamePhase.PLAYER_CHOICE)
+            val gameState = baseState.copy(phase = GamePhase.PLAYER_CHOICE)
             whenever(gameService.resolveAuction("game-1", "player-1", true)).thenReturn(gameState)
 
             sendEnvelope(
@@ -1039,6 +1090,7 @@ class GameWebSocketHandlerTest {
             val payload1 = decodePayload(response1, GameStatePayload.serializer())
 
             assertEquals(gameState, payload1.state)
+            assertEquals(gameState.createViewForPlayer("player-1"), payload1.stateView)
 
             val response2 = captureResponse(session2)
             assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
@@ -1047,6 +1099,7 @@ class GameWebSocketHandlerTest {
             val payload2 = decodePayload(response2, GameStatePayload.serializer())
 
             assertEquals(gameState, payload2.state)
+            assertEquals(gameState.createViewForPlayer("player-2"), payload2.stateView)
         }
 
     @Test
@@ -1105,9 +1158,10 @@ class GameWebSocketHandlerTest {
         runTest(testDispatcher.scheduler) {
             whenever(connectionRegistry.gameIdFor("session-1")).thenReturn("game-1")
             whenever(connectionRegistry.playerIdFor("session-1")).thenReturn("player-1")
+            whenever(connectionRegistry.playerIdFor("session-2")).thenReturn("player-2")
             whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(session1, session2))
 
-            val gameState = GameState(phase = GamePhase.PLAYER_CHOICE)
+            val gameState = baseState.copy(phase = GamePhase.PLAYER_CHOICE)
             whenever(gameService.finishTradeReveal("game-1", "player-1")).thenReturn(gameState)
 
             sendEnvelope(
@@ -1125,6 +1179,7 @@ class GameWebSocketHandlerTest {
             val payload1 = decodePayload(response1, GameStatePayload.serializer())
 
             assertEquals(gameState, payload1.state)
+            assertEquals(gameState.createViewForPlayer("player-1"), payload1.stateView)
 
             val response2 = captureResponse(session2)
             assertEquals(WebSocketType.GAME_STATE_UPDATED, response2.type)
@@ -1133,6 +1188,7 @@ class GameWebSocketHandlerTest {
             val payload2 = decodePayload(response2, GameStatePayload.serializer())
 
             assertEquals(gameState, payload2.state)
+            assertEquals(gameState.createViewForPlayer("player-2"), payload2.stateView)
         }
 
     @Test

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -10,7 +10,7 @@ import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.enums.GameErrorReason
 import at.aau.kuhhandel.shared.enums.GamePhase
 import at.aau.kuhhandel.shared.model.GameState
-import at.aau.kuhhandel.shared.model.PlayerState
+import at.aau.kuhhandel.shared.model.Player
 import at.aau.kuhhandel.shared.websocket.AuctionBuyBackPayload
 import at.aau.kuhhandel.shared.websocket.CreateGamePayload
 import at.aau.kuhhandel.shared.websocket.ErrorPayload
@@ -237,7 +237,7 @@ class GameWebSocketHandlerTest {
         runTest(testDispatcher.scheduler) {
             val state =
                 GameState(
-                    players = listOf(PlayerState("player-1", "Player 1")),
+                    players = listOf(Player("player-1", "Player 1")),
                     hostPlayerId = "player-1",
                 )
 
@@ -339,7 +339,7 @@ class GameWebSocketHandlerTest {
         runTest(testDispatcher.scheduler) {
             val returnedState =
                 GameState(
-                    players = listOf(PlayerState("player-2", "Player 2")),
+                    players = listOf(Player("player-2", "Player 2")),
                     hostPlayerId = "player-2",
                 )
 
@@ -430,7 +430,7 @@ class GameWebSocketHandlerTest {
         runTest(testDispatcher.scheduler) {
             val returnedState =
                 GameState(
-                    players = listOf(PlayerState("player-2", "Player 2")),
+                    players = listOf(Player("player-2", "Player 2")),
                     hostPlayerId = "player-2",
                 )
 
@@ -455,7 +455,7 @@ class GameWebSocketHandlerTest {
         runTest(testDispatcher.scheduler) {
             val returnedState =
                 GameState(
-                    players = listOf(PlayerState("player-1", "Player 1")),
+                    players = listOf(Player("player-1", "Player 1")),
                     hostPlayerId = "player-1",
                 )
             val gameSession =
@@ -665,7 +665,7 @@ class GameWebSocketHandlerTest {
             whenever(connectionRegistry.gameIdFor("session-B")).thenReturn("game-1")
             whenever(connectionRegistry.playerIdFor("session-B")).thenReturn("player-B")
 
-            val stateAfterALeaves = GameState(players = listOf(PlayerState("player-B", "Player B")))
+            val stateAfterALeaves = GameState(players = listOf(Player("player-B", "Player B")))
             whenever(gameService.leaveGame("game-1", "player-A")).thenReturn(stateAfterALeaves)
 
             whenever(connectionRegistry.sessionsFor("game-1")).thenReturn(setOf(sessionB))

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
@@ -19,6 +19,67 @@ data class GameState(
     // The last event that occurred, e.g. a money bonus from a donkey
     val lastEvent: GameEvent? = null,
 ) {
+    fun createViewForPlayer(playerId: String): GameStateView {
+        val localPlayer = this.players.find { it.id == playerId }
+        checkNotNull(localPlayer) {
+            "Viewing player $playerId not found in game state"
+        }
+
+        val opponents =
+            this.players
+                .filter { it.id != playerId }
+                .map { player ->
+                    Opponent(
+                        id = player.id,
+                        name = player.name,
+                        animals = player.animals,
+                        moneyCardCount = player.moneyCards.size,
+                    )
+                }
+
+        val tradeStateView =
+            this.tradeState?.let { tradeState ->
+                val isRevealPhase = this.phase == GamePhase.TRADE_REVEAL
+
+                val initiatorCards =
+                    if (isRevealPhase || playerId == tradeState.initiatorId) {
+                        tradeState.initiatorMoneyCards
+                    } else {
+                        null
+                    }
+
+                val targetCards =
+                    if (isRevealPhase) {
+                        tradeState.targetMoneyCards
+                    } else {
+                        null
+                    }
+
+                TradeStateView(
+                    initiatorId = tradeState.initiatorId,
+                    targetId = tradeState.targetId,
+                    requestedAnimalType = tradeState.requestedAnimalType,
+                    initiatorCardCount = tradeState.initiatorMoneyCards.size,
+                    targetCardCount = targetCards?.size,
+                    visibleInitiatorCards = initiatorCards?.toList(),
+                    visibleTargetCards = targetCards?.toList(),
+                )
+            }
+
+        return GameStateView(
+            phase = this.phase,
+            localPlayer = localPlayer,
+            opponents = opponents,
+            hostPlayerId = checkNotNull(this.hostPlayerId) { "Game state has no host" },
+            roundNumber = this.roundNumber,
+            currentPlayerIndex = this.currentPlayerIndex,
+            deckSize = this.deck.size(),
+            auctionState = this.auctionState,
+            tradeState = tradeStateView,
+            lastEvent = this.lastEvent,
+        )
+    }
+
     companion object {
         fun fromCreatingPlayer(
             id: String,

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
@@ -80,6 +80,24 @@ data class GameState(
         )
     }
 
+    fun updatePlayer(
+        playerId: String,
+        transform: (Player) -> Player,
+    ): GameState {
+        var playerFound = false
+        val updatedPlayers =
+            this.players.map { player ->
+                if (player.id == playerId) {
+                    playerFound = true
+                    transform(player)
+                } else {
+                    player
+                }
+            }
+        check(playerFound) { "Player $playerId not found to update" }
+        return this.copy(players = updatedPlayers)
+    }
+
     companion object {
         fun fromCreatingPlayer(
             id: String,

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
@@ -43,14 +43,14 @@ data class GameState(
 
                 val initiatorCards =
                     if (isRevealPhase || playerId == tradeState.initiatorId) {
-                        tradeState.initiatorMoneyCards
+                        tradeState.offeredMoneyCards
                     } else {
                         null
                     }
 
                 val targetCards =
                     if (isRevealPhase) {
-                        tradeState.targetMoneyCards
+                        tradeState.counterOfferedMoneyCards
                     } else {
                         null
                     }
@@ -59,7 +59,7 @@ data class GameState(
                     initiatorId = tradeState.initiatorId,
                     targetId = tradeState.targetId,
                     requestedAnimalType = tradeState.requestedAnimalType,
-                    initiatorCardCount = tradeState.initiatorMoneyCards.size,
+                    initiatorCardCount = tradeState.offeredMoneyCards.size,
                     targetCardCount = targetCards?.size,
                     visibleInitiatorCards = initiatorCards?.toList(),
                     visibleTargetCards = targetCards?.toList(),

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameState.kt
@@ -10,7 +10,7 @@ data class GameState(
     val deck: AnimalDeck = AnimalDeck(),
     val currentFaceUpCard: AnimalCard? = null,
     val currentPlayerIndex: Int = -1,
-    val players: List<PlayerState> = emptyList(),
+    val players: List<Player> = emptyList(),
     val hostPlayerId: String? = null,
     // Active auction state, null if no auction is running
     val auctionState: AuctionState? = null,
@@ -32,7 +32,7 @@ data class GameState(
                 currentPlayerIndex = -1,
                 players =
                     listOf(
-                        PlayerState(
+                        Player(
                             id = id,
                             name = name,
                         ),

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameStateView.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/GameStateView.kt
@@ -1,0 +1,18 @@
+package at.aau.kuhhandel.shared.model
+
+import at.aau.kuhhandel.shared.enums.GamePhase
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GameStateView(
+    val phase: GamePhase,
+    val localPlayer: Player,
+    val opponents: List<Opponent>,
+    val hostPlayerId: String,
+    val roundNumber: Int,
+    val currentPlayerIndex: Int,
+    val deckSize: Int,
+    val auctionState: AuctionState?,
+    val tradeState: TradeStateView?,
+    val lastEvent: GameEvent?,
+)

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/Opponent.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/Opponent.kt
@@ -1,0 +1,11 @@
+package at.aau.kuhhandel.shared.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Opponent(
+    val id: String,
+    val name: String,
+    val animals: List<AnimalCard>,
+    val moneyCardCount: Int,
+)

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/Player.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/Player.kt
@@ -3,7 +3,7 @@ package at.aau.kuhhandel.shared.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class PlayerState(
+data class Player(
     val id: String,
     val name: String,
     val animals: List<AnimalCard> = emptyList(),

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/TradeState.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/TradeState.kt
@@ -23,6 +23,6 @@ data class TradeState(
     val isResolved: Boolean = false,
     // New fields to replace offeredMoney, offeredMoneyCardIds,
     // counterOfferedMoney, and counterOfferedMoneyCardIds
-    val initiatorMoneyCards: Set<MoneyCard> = emptySet(),
-    val targetMoneyCards: Set<MoneyCard>? = null,
+    val offeredMoneyCards: Set<MoneyCard> = emptySet(),
+    val counterOfferedMoneyCards: Set<MoneyCard>? = null,
 )

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/TradeState.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/TradeState.kt
@@ -21,4 +21,8 @@ data class TradeState(
     val counterOfferedMoneyCardIds: Set<String> = emptySet(),
     // Can later be used to mark the trade as finished
     val isResolved: Boolean = false,
+    // New fields to replace offeredMoney, offeredMoneyCardIds,
+    // counterOfferedMoney, and counterOfferedMoneyCardIds
+    val initiatorMoneyCards: Set<MoneyCard> = emptySet(),
+    val targetMoneyCards: Set<MoneyCard>? = null,
 )

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/TradeStateView.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/model/TradeStateView.kt
@@ -1,0 +1,15 @@
+package at.aau.kuhhandel.shared.model
+
+import at.aau.kuhhandel.shared.enums.AnimalType
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TradeStateView(
+    val initiatorId: String,
+    val targetId: String,
+    val requestedAnimalType: AnimalType,
+    val initiatorCardCount: Int,
+    val targetCardCount: Int?,
+    val visibleInitiatorCards: List<MoneyCard>? = null,
+    val visibleTargetCards: List<MoneyCard>? = null,
+)

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
@@ -2,6 +2,7 @@ package at.aau.kuhhandel.shared.websocket
 
 import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.model.GameState
+import at.aau.kuhhandel.shared.model.GameStateView
 import kotlinx.serialization.Serializable
 
 /**
@@ -20,6 +21,7 @@ data class GameCreatedPayload(
     val gameId: String,
     val playerId: String,
     val state: GameState,
+    val stateView: GameStateView? = null,
 )
 
 /**
@@ -28,6 +30,7 @@ data class GameCreatedPayload(
 @Serializable
 data class GameStatePayload(
     val state: GameState,
+    val stateView: GameStateView? = null,
 )
 
 /**
@@ -46,6 +49,7 @@ data class JoinGamePayload(
 data class GameJoinedPayload(
     val playerId: String,
     val state: GameState,
+    val stateView: GameStateView? = null,
 )
 
 /**

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
@@ -25,7 +25,7 @@ data class GameCreatedPayload(
 )
 
 /**
- * Payload used by GAME_STARTED, GAME_STATE_UPDATED, and SNAPSHOT events
+ * Payload used by GAME_STATE_UPDATED and SNAPSHOT events
  */
 @Serializable
 data class GameStatePayload(

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/GameStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/GameStateTest.kt
@@ -41,8 +41,8 @@ class GameStateTest {
                     initiatorId = "player-1",
                     targetId = "player-2",
                     requestedAnimalType = AnimalType.COW,
-                    initiatorMoneyCards = setOf(MoneyCard("money-50-1", 50)),
-                    targetMoneyCards = null,
+                    offeredMoneyCards = setOf(MoneyCard("money-50-1", 50)),
+                    counterOfferedMoneyCards = null,
                 ),
             lastEvent = null,
         )
@@ -114,10 +114,10 @@ class GameStateTest {
         assertEquals(tradeState?.initiatorId, tradeView.initiatorId)
         assertEquals(tradeState?.targetId, tradeView.targetId)
         assertEquals(tradeState?.requestedAnimalType, tradeView.requestedAnimalType)
-        assertEquals(tradeState?.initiatorMoneyCards?.size, tradeView.initiatorCardCount)
-        assertEquals(tradeState?.targetMoneyCards?.size, tradeView.targetCardCount)
-        assertEquals(tradeState?.initiatorMoneyCards, tradeView.visibleInitiatorCards?.toSet())
-        assertEquals(tradeState?.targetMoneyCards, tradeView.visibleTargetCards?.toSet())
+        assertEquals(tradeState?.offeredMoneyCards?.size, tradeView.initiatorCardCount)
+        assertEquals(tradeState?.counterOfferedMoneyCards?.size, tradeView.targetCardCount)
+        assertEquals(tradeState?.offeredMoneyCards, tradeView.visibleInitiatorCards?.toSet())
+        assertEquals(tradeState?.counterOfferedMoneyCards, tradeView.visibleTargetCards?.toSet())
     }
 
     @Test
@@ -141,8 +141,8 @@ class GameStateTest {
         assertEquals(tradeState?.initiatorId, tradeView.initiatorId)
         assertEquals(tradeState?.targetId, tradeView.targetId)
         assertEquals(tradeState?.requestedAnimalType, tradeView.requestedAnimalType)
-        assertEquals(tradeState?.initiatorMoneyCards?.size, tradeView.initiatorCardCount)
-        assertEquals(tradeState?.targetMoneyCards?.size, tradeView.targetCardCount)
+        assertEquals(tradeState?.offeredMoneyCards?.size, tradeView.initiatorCardCount)
+        assertEquals(tradeState?.counterOfferedMoneyCards?.size, tradeView.targetCardCount)
         assertNull(tradeView.visibleInitiatorCards)
         assertNull(tradeView.visibleTargetCards)
     }
@@ -154,7 +154,7 @@ class GameStateTest {
                 phase = GamePhase.TRADE_REVEAL,
                 tradeState =
                     baseState.tradeState?.copy(
-                        targetMoneyCards = setOf(MoneyCard("money-0-2", 0)),
+                        counterOfferedMoneyCards = setOf(MoneyCard("money-0-2", 0)),
                     ),
             )
 
@@ -166,9 +166,9 @@ class GameStateTest {
         assertEquals(tradeState?.initiatorId, tradeView.initiatorId)
         assertEquals(tradeState?.targetId, tradeView.targetId)
         assertEquals(tradeState?.requestedAnimalType, tradeView.requestedAnimalType)
-        assertEquals(tradeState?.initiatorMoneyCards?.size, tradeView.initiatorCardCount)
-        assertEquals(tradeState?.targetMoneyCards?.size, tradeView.targetCardCount)
-        assertEquals(tradeState?.initiatorMoneyCards, tradeView.visibleInitiatorCards?.toSet())
-        assertEquals(tradeState?.targetMoneyCards, tradeView.visibleTargetCards?.toSet())
+        assertEquals(tradeState?.offeredMoneyCards?.size, tradeView.initiatorCardCount)
+        assertEquals(tradeState?.counterOfferedMoneyCards?.size, tradeView.targetCardCount)
+        assertEquals(tradeState?.offeredMoneyCards, tradeView.visibleInitiatorCards?.toSet())
+        assertEquals(tradeState?.counterOfferedMoneyCards, tradeView.visibleTargetCards?.toSet())
     }
 }

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/GameStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/GameStateTest.kt
@@ -1,12 +1,52 @@
 package at.aau.kuhhandel.shared.model
 
+import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.enums.GamePhase
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class GameStateTest {
+    private val baseState =
+        GameState(
+            phase = GamePhase.TRADE_RESPONSE,
+            roundNumber = 1,
+            deck = AnimalDeck(cards = listOf(AnimalCard("donkey-1", AnimalType.DONKEY))),
+            currentPlayerIndex = 0,
+            players =
+                listOf(
+                    Player(
+                        id = "player-1",
+                        name = "Player 1",
+                        moneyCards = listOf(MoneyCard("money-10-1", 10)),
+                    ),
+                    Player(
+                        id = "player-2",
+                        name = "Player 3",
+                        animals = listOf(AnimalCard("cow-1", AnimalType.COW)),
+                        moneyCards = listOf(MoneyCard("money-0-1", 0), MoneyCard("money-20-1", 20)),
+                    ),
+                    Player(
+                        id = "player-3",
+                        name = "Player 3",
+                        moneyCards = listOf(MoneyCard("money-100-1", 100)),
+                    ),
+                ),
+            hostPlayerId = "player-1",
+            auctionState = null,
+            tradeState =
+                TradeState(
+                    initiatorId = "player-1",
+                    targetId = "player-2",
+                    requestedAnimalType = AnimalType.COW,
+                    initiatorMoneyCards = setOf(MoneyCard("money-50-1", 50)),
+                    targetMoneyCards = null,
+                ),
+            lastEvent = null,
+        )
+
     @Test
     fun test_defaultGameState() {
         val state = GameState()
@@ -23,13 +63,13 @@ class GameStateTest {
 
     @Test
     fun test_gameState_withCustomValues() {
-        val card = AnimalCard(id = "1", type = at.aau.kuhhandel.shared.enums.AnimalType.COW)
+        val card = AnimalCard(id = "1", type = AnimalType.COW)
         val auctionState = AuctionState(auctionCard = card, auctioneerId = "p1")
         val tradeState =
             TradeState(
                 initiatorId = "p1",
                 targetId = "p2",
-                requestedAnimalType = at.aau.kuhhandel.shared.enums.AnimalType.DOG,
+                requestedAnimalType = AnimalType.DOG,
             )
 
         val state =
@@ -51,5 +91,84 @@ class GameStateTest {
         assertEquals(auctionState, state.auctionState)
         assertEquals(tradeState, state.tradeState)
         assertEquals(1, state.deck.size())
+    }
+
+    @Test
+    fun test_createViewForPlayer_showsTradeData_forTradeInitiator() {
+        val view = baseState.createViewForPlayer("player-1")
+
+        assertEquals(baseState.phase, view.phase)
+        assertEquals("player-1", view.localPlayer.id)
+        assertTrue(view.opponents.any { it.id == "player-2" })
+        assertTrue(view.opponents.any { it.id == "player-3" })
+        assertEquals(baseState.hostPlayerId, view.hostPlayerId)
+        assertEquals(baseState.roundNumber, view.roundNumber)
+        assertEquals(baseState.currentPlayerIndex, view.currentPlayerIndex)
+        assertEquals(baseState.deck.size(), view.deckSize)
+        assertEquals(baseState.auctionState, view.auctionState)
+        assertEquals(baseState.lastEvent, view.lastEvent)
+
+        val tradeState = baseState.tradeState
+        val tradeView = view.tradeState
+        assertNotNull(tradeView)
+        assertEquals(tradeState?.initiatorId, tradeView.initiatorId)
+        assertEquals(tradeState?.targetId, tradeView.targetId)
+        assertEquals(tradeState?.requestedAnimalType, tradeView.requestedAnimalType)
+        assertEquals(tradeState?.initiatorMoneyCards?.size, tradeView.initiatorCardCount)
+        assertEquals(tradeState?.targetMoneyCards?.size, tradeView.targetCardCount)
+        assertEquals(tradeState?.initiatorMoneyCards, tradeView.visibleInitiatorCards?.toSet())
+        assertEquals(tradeState?.targetMoneyCards, tradeView.visibleTargetCards?.toSet())
+    }
+
+    @Test
+    fun test_createViewForPlayer_doesNotShowTradeData_forTradeObserverBeforeReveal() {
+        val view = baseState.createViewForPlayer("player-3")
+
+        assertEquals(baseState.phase, view.phase)
+        assertEquals("player-3", view.localPlayer.id)
+        assertTrue(view.opponents.any { it.id == "player-1" })
+        assertTrue(view.opponents.any { it.id == "player-2" })
+        assertEquals(baseState.hostPlayerId, view.hostPlayerId)
+        assertEquals(baseState.roundNumber, view.roundNumber)
+        assertEquals(baseState.currentPlayerIndex, view.currentPlayerIndex)
+        assertEquals(baseState.deck.size(), view.deckSize)
+        assertEquals(baseState.auctionState, view.auctionState)
+        assertEquals(baseState.lastEvent, view.lastEvent)
+
+        val tradeState = baseState.tradeState
+        val tradeView = view.tradeState
+        assertNotNull(tradeView)
+        assertEquals(tradeState?.initiatorId, tradeView.initiatorId)
+        assertEquals(tradeState?.targetId, tradeView.targetId)
+        assertEquals(tradeState?.requestedAnimalType, tradeView.requestedAnimalType)
+        assertEquals(tradeState?.initiatorMoneyCards?.size, tradeView.initiatorCardCount)
+        assertEquals(tradeState?.targetMoneyCards?.size, tradeView.targetCardCount)
+        assertNull(tradeView.visibleInitiatorCards)
+        assertNull(tradeView.visibleTargetCards)
+    }
+
+    @Test
+    fun test_createViewForPlayer_showsTradeData_forTradeObserverDuringReveal() {
+        val revealState =
+            baseState.copy(
+                phase = GamePhase.TRADE_REVEAL,
+                tradeState =
+                    baseState.tradeState?.copy(
+                        targetMoneyCards = setOf(MoneyCard("money-0-2", 0)),
+                    ),
+            )
+
+        val view = revealState.createViewForPlayer("player-3")
+        val tradeState = revealState.tradeState
+        val tradeView = view.tradeState
+
+        assertNotNull(tradeView)
+        assertEquals(tradeState?.initiatorId, tradeView.initiatorId)
+        assertEquals(tradeState?.targetId, tradeView.targetId)
+        assertEquals(tradeState?.requestedAnimalType, tradeView.requestedAnimalType)
+        assertEquals(tradeState?.initiatorMoneyCards?.size, tradeView.initiatorCardCount)
+        assertEquals(tradeState?.targetMoneyCards?.size, tradeView.targetCardCount)
+        assertEquals(tradeState?.initiatorMoneyCards, tradeView.visibleInitiatorCards?.toSet())
+        assertEquals(tradeState?.targetMoneyCards, tradeView.visibleTargetCards?.toSet())
     }
 }

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/GameStateTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/GameStateTest.kt
@@ -3,6 +3,7 @@ package at.aau.kuhhandel.shared.model
 import at.aau.kuhhandel.shared.enums.AnimalType
 import at.aau.kuhhandel.shared.enums.GamePhase
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -170,5 +171,27 @@ class GameStateTest {
         assertEquals(tradeState?.counterOfferedMoneyCards?.size, tradeView.targetCardCount)
         assertEquals(tradeState?.offeredMoneyCards, tradeView.visibleInitiatorCards?.toSet())
         assertEquals(tradeState?.counterOfferedMoneyCards, tradeView.visibleTargetCards?.toSet())
+    }
+
+    @Test
+    fun test_updatePlayer_updatesPlayer_ifPlayerExists() {
+        val updatedState =
+            baseState.updatePlayer("player-2") { player ->
+                player.copy(moneyCards = player.moneyCards - MoneyCard("money-20-1", 20))
+            }
+
+        val updatedPlayer = updatedState.players.first { it.id == "player-2" }
+        assertEquals(1, updatedPlayer.moneyCards.size)
+        assertTrue(updatedPlayer.moneyCards.none { it.id == "money-20-1" })
+
+        assertEquals(
+            baseState.players.filter { it.id != "player-2" },
+            updatedState.players.filter { it.id != "player-2" },
+        )
+    }
+
+    @Test
+    fun test_updatePlayer_throws_ifPlayerDoesNotExist() {
+        assertThrows<IllegalStateException> { baseState.updatePlayer("player-4") { it } }
     }
 }

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/PlayerTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/model/PlayerTest.kt
@@ -3,11 +3,11 @@ package at.aau.kuhhandel.shared.model
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
-class PlayerStateTest {
+class PlayerTest {
     @Test
     fun test_totalMoney() {
         val player =
-            PlayerState(
+            Player(
                 id = "1",
                 name = "Test",
                 moneyCards =

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
@@ -1,7 +1,10 @@
 package at.aau.kuhhandel.shared.websocket
 
 import at.aau.kuhhandel.shared.enums.AnimalType
+import at.aau.kuhhandel.shared.enums.GamePhase
 import at.aau.kuhhandel.shared.model.GameState
+import at.aau.kuhhandel.shared.model.GameStateView
+import at.aau.kuhhandel.shared.model.Player
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
@@ -70,7 +73,13 @@ class WebSocketProtocolTest {
 
     @Test
     fun `GameCreatedPayload round-trips`() {
-        val payload = GameCreatedPayload(gameId = "Id", playerId = "P1", state = GameState())
+        val payload =
+            GameCreatedPayload(
+                gameId = "Id",
+                playerId = "P1",
+                state = GameState(),
+                stateView = testGameStateView(),
+            )
 
         val encoded = json.encodeToString(GameCreatedPayload.serializer(), payload)
         val decoded = json.decodeFromString(GameCreatedPayload.serializer(), encoded)
@@ -83,7 +92,7 @@ class WebSocketProtocolTest {
 
     @Test
     fun `GameStatePayload round-trips`() {
-        val payload = GameStatePayload(state = GameState())
+        val payload = GameStatePayload(state = GameState(), stateView = testGameStateView())
 
         val encoded = json.encodeToString(GameStatePayload.serializer(), payload)
         val decoded = json.decodeFromString(GameStatePayload.serializer(), encoded)
@@ -106,7 +115,12 @@ class WebSocketProtocolTest {
 
     @Test
     fun `GameJoinedPayload round-trips`() {
-        val payload = GameJoinedPayload(playerId = "player-1", state = GameState())
+        val payload =
+            GameJoinedPayload(
+                playerId = "player-1",
+                state = GameState(),
+                stateView = testGameStateView(),
+            )
 
         val encoded = json.encodeToString(GameJoinedPayload.serializer(), payload)
         val decoded = json.decodeFromString(GameJoinedPayload.serializer(), encoded)
@@ -235,4 +249,18 @@ class WebSocketProtocolTest {
         assert(!encoded.contains("playerId"))
         assert(!encoded.contains("payload"))
     }
+
+    private fun testGameStateView() =
+        GameStateView(
+            phase = GamePhase.NOT_STARTED,
+            localPlayer = Player("player-1", "Player 1"),
+            opponents = emptyList(),
+            hostPlayerId = "player-1",
+            roundNumber = 0,
+            currentPlayerIndex = -1,
+            deckSize = 5,
+            auctionState = null,
+            tradeState = null,
+            lastEvent = null,
+        )
 }


### PR DESCRIPTION
Implements `GameStateView` in the shared and server modules for player-specific game state information.

**Client-Oriented Changes:**
- Created shared data models `GameStateView`, `Opponent`, and `TradeStateView` to hide player-specific information.
- Added `GameStateView` fields to `GameCreatedPayload`, `GameStatePayload`, and `GameJoinedPayload` and populated these fields in `GameWebSocketHandler`.

**Other Changes:**
- Modified `GameSession` to transfer players' money cards offered during a trade into the `TradeState` instead of only storing the card IDs there.
- Modified `respondToTrade()` of `GameSession` to only store the target player's cards in the `TradeState` and moved the trade result handling into `endTradeReveal()`.
- Replaced all raw `!!` operators in `GameSession` with descriptive assertions.
- Wrapped the loop inside `broadcastStateUpdate()` of `GameWebSocketHandler` with per-player exception handling to prevent single-client network drops from crashing the room broadcast.
- Renamed `PlayerState` to `Player` in all modules to avoid confusion with similarly sounding `GameState`, `AuctionState`, and `TradeState`.

**Notes:**
- The addition of `GameStateView` is fully backwards-compatible for the client, as all existing payload fields remain fully intact.
- Although the PR modifies how trades are handled on the server, the trading functionality is not yet implemented on the client, so this change, too, is compatible with the client.

**Closed Issues:**
- #264
- #265