### PR TITLE
Feat: check room code before joining

### DIFF
--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
@@ -395,7 +395,7 @@ class GameRepository(
                     return
                 }
 
-                // 2. Try GameJoinedPayload (includes playerId but NOT gameId)
+                // 2. Try GameJoinedPayload (includes gameId and playerId)
                 val joined =
                     runCatching {
                         WebSocketJson.json.decodeFromJsonElement(

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/network/game/GameRepository.kt
@@ -2,6 +2,7 @@ package at.aau.kuhhandel.app.network.game
 
 import at.aau.kuhhandel.app.data.TokenStorage
 import at.aau.kuhhandel.shared.enums.AnimalType
+import at.aau.kuhhandel.shared.enums.GameErrorReason
 import at.aau.kuhhandel.shared.model.GameState
 import at.aau.kuhhandel.shared.model.GameStateView
 import at.aau.kuhhandel.shared.websocket.ErrorPayload
@@ -76,7 +77,7 @@ class GameRepository(
         playerName: String,
     ) {
         ensureConnected()
-        _state.update { it.copy(gameId = gameId, errorMessage = null) }
+        _state.update { it.copy(errorMessage = null) }
         client.joinGame(gameId, playerName)
     }
 
@@ -405,15 +406,14 @@ class GameRepository(
                     }.getOrNull()
 
                 if (joined != null) {
-                    // The repository should already have the game ID
-                    val resolvedGameId = _state.value.gameId ?: ""
                     tokenStorage.saveSession(
-                        resolvedGameId,
+                        joined.gameId,
                         joined.playerId,
                         joined.reconnectToken,
                     )
                     _state.update {
                         it.copy(
+                            gameId = joined.gameId,
                             myPlayerId = it.myPlayerId ?: joined.playerId,
                             gameState = joined.state,
                             gameStateView = joined.stateView,
@@ -501,7 +501,12 @@ class GameRepository(
                         invalidMessage = "Invalid ERROR message",
                     ) ?: return
 
-                _state.update { it.copy(errorMessage = payload.message) }
+                val friendlyMessage =
+                    runCatching {
+                        GameErrorReason.valueOf(payload.message).toUserMessage()
+                    }.getOrDefault(payload.message)
+
+                _state.update { it.copy(errorMessage = friendlyMessage) }
             }
 
             else -> Unit

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/creation/LobbyCreationScreen.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/creation/LobbyCreationScreen.kt
@@ -32,6 +32,7 @@ fun RoomCreationScreen(
 ) {
     LaunchedEffect(uiState.isCreated, uiState.gameId) {
         if (uiState.isCreated && uiState.gameId != null) {
+            kotlinx.coroutines.delay(500)
             onLobbyCreated(uiState.gameId)
         }
     }

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/joining/LobbyJoiningViewModel.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/joining/LobbyJoiningViewModel.kt
@@ -49,7 +49,7 @@ class LobbyJoiningViewModel(
                 playerNameError = nameError,
                 isLoading = loading || repoState.isConnecting,
                 errorMessage = localError ?: repoState.errorMessage,
-                isJoined = repoState.gameId != null,
+                isJoined = repoState.gameId != null && repoState.gameState != null,
                 joinedLobbyCode = repoState.gameId,
             )
         }.stateIn(

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/lobby/LobbyScreen.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/lobby/LobbyScreen.kt
@@ -1,6 +1,7 @@
 package at.aau.kuhhandel.app.ui.menu.lobby
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,6 +30,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import at.aau.kuhhandel.app.ui.components.MenuBackground
 import at.aau.kuhhandel.app.ui.components.MenuCard
+import at.aau.kuhhandel.app.ui.theme.DarkPurple
+import at.aau.kuhhandel.app.ui.theme.DefaultPurple
+import at.aau.kuhhandel.app.ui.theme.LightPurple
+import at.aau.kuhhandel.app.ui.theme.WhitePurple
 
 @Composable
 fun LobbyScreen(
@@ -163,8 +168,23 @@ private fun PlayerListItem(player: PlayerDisplayItem) {
             Modifier
                 .fillMaxWidth()
                 .background(
-                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    color =
+                        if (player.isMe) {
+                            WhitePurple
+                        } else {
+                            MaterialTheme.colorScheme.surfaceVariant
+                        },
                     shape = RoundedCornerShape(24.dp),
+                ).then(
+                    if (player.isMe) {
+                        Modifier.border(
+                            width = 2.dp,
+                            color = DefaultPurple,
+                            shape = RoundedCornerShape(24.dp),
+                        )
+                    } else {
+                        Modifier
+                    },
                 ).padding(12.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
@@ -178,7 +198,7 @@ private fun PlayerListItem(player: PlayerDisplayItem) {
                     Modifier
                         .size(40.dp)
                         .clip(CircleShape)
-                        .background(MaterialTheme.colorScheme.primary),
+                        .background(DefaultPurple),
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
@@ -191,10 +211,29 @@ private fun PlayerListItem(player: PlayerDisplayItem) {
             Spacer(modifier = Modifier.size(12.dp))
 
             Column {
-                Text(
-                    player.name,
-                    style = MaterialTheme.typography.bodyMedium,
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        player.name,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    if (player.isMe) {
+                        Spacer(modifier = Modifier.size(8.dp))
+                        Box(
+                            modifier =
+                                Modifier
+                                    .background(
+                                        color = LightPurple,
+                                        shape = RoundedCornerShape(8.dp),
+                                    ).padding(horizontal = 6.dp, vertical = 2.dp),
+                        ) {
+                            Text(
+                                "(You)",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = DarkPurple,
+                            )
+                        }
+                    }
+                }
                 Text(
                     if (player.isHost) "Host" else "Player",
                     style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/lobby/LobbyViewModel.kt
+++ b/app/src/main/kotlin/at/aau/kuhhandel/app/ui/menu/lobby/LobbyViewModel.kt
@@ -13,6 +13,7 @@ data class PlayerDisplayItem(
     val name: String,
     val isHost: Boolean,
     val isReady: Boolean,
+    val isMe: Boolean = false,
 )
 
 data class LobbyUiState(
@@ -41,11 +42,12 @@ class LobbyViewModel(
                                 name = playerState.name.ifBlank { playerState.id },
                                 isHost = index == 0,
                                 isReady = repoState.isConnected,
+                                isMe = playerState.id == repoState.myPlayerId,
                             )
                         }.orEmpty()
                         .ifEmpty {
                             listOf(
-                                PlayerDisplayItem("You", true, repoState.isConnected),
+                                PlayerDisplayItem("You", true, repoState.isConnected, true),
                             )
                         }
 

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
@@ -555,6 +555,7 @@ class GameRepositoryTest {
                             at.aau.kuhhandel.shared.websocket.GameJoinedPayload
                                 .serializer(),
                             at.aau.kuhhandel.shared.websocket.GameJoinedPayload(
+                                gameId = "g1",
                                 playerId = "player-7da6",
                                 reconnectToken = "test-token",
                                 state = state,

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/game/GameRepositoryTest.kt
@@ -442,14 +442,19 @@ class GameRepositoryTest {
     fun `error envelopes update the state and can be cleared`() {
         runBlocking {
             val harness = createHarness()
+            val reason = at.aau.kuhhandel.shared.enums.GameErrorReason.GAME_NOT_FOUND
+            val technicalName = reason.name
+            val expectedFriendly = "Game not found. Please check the code."
 
+            // Must call an action first to ensure connection is open and collector is running
             harness.createGame()
-            harness.receiveError("Invalid move")
 
-            assertEquals("Invalid move", harness.state.errorMessage)
+            harness.receiveError(technicalName)
+
+            assertEquals(expectedFriendly, harness.state.errorMessage)
 
             harness.clearError()
-            assertNull(harness.state.errorMessage)
+            assertEquals(null, harness.state.errorMessage)
         }
     }
 

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/LobbyJoiningViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/LobbyJoiningViewModelTest.kt
@@ -3,6 +3,7 @@ package at.aau.kuhhandel.app.network.viewmodel
 import at.aau.kuhhandel.app.network.game.GameRepository
 import at.aau.kuhhandel.app.network.game.GameRepositoryState
 import at.aau.kuhhandel.app.ui.menu.joining.LobbyJoiningViewModel
+import at.aau.kuhhandel.shared.model.GameState
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -169,7 +170,7 @@ class LobbyJoiningViewModelTest {
                 viewModel.uiState.collect {}
             }
 
-            repoStateFlow.value = GameRepositoryState(gameId = "54321")
+            repoStateFlow.value = GameRepositoryState(gameId = "54321", gameState = GameState())
             advanceUntilIdle()
 
             assertTrue(viewModel.uiState.value.isJoined)

--- a/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/LobbyViewModelTest.kt
+++ b/app/src/test/kotlin/at/aau/kuhhandel/app/network/viewmodel/LobbyViewModelTest.kt
@@ -112,6 +112,35 @@ class LobbyViewModelTest {
     }
 
     @Test
+    fun `isMe flag is set correctly for the local player`() {
+        runTest {
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                viewModel.uiState.collect {}
+            }
+
+            val players =
+                listOf(
+                    Player(id = "p1", name = "Alice"),
+                    Player(id = "p2", name = "Bob"),
+                )
+            val gameState = GameState(players = players, phase = GamePhase.NOT_STARTED)
+
+            repoStateFlow.value =
+                GameRepositoryState(
+                    isConnected = true,
+                    gameState = gameState,
+                    myPlayerId = "p2",
+                )
+
+            advanceUntilIdle()
+
+            val uiState = viewModel.uiState.value
+            assertFalse(uiState.players[0].isMe) // Alice
+            assertTrue(uiState.players[1].isMe) // Bob
+        }
+    }
+
+    @Test
     fun `canStartGame is true only when host and connected and at least 2 players`() {
         runTest {
             backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {

--- a/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
+++ b/server/src/main/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandler.kt
@@ -239,6 +239,7 @@ class GameWebSocketHandler(
                     WebSocketJson.json.encodeToJsonElement(
                         GameJoinedPayload.serializer(),
                         GameJoinedPayload(
+                            gameId = joinedGameId,
                             playerId = playerId,
                             reconnectToken = token,
                             state = state,

--- a/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
+++ b/server/src/test/kotlin/at/aau/kuhhandel/server/websocket/GameWebSocketHandlerTest.kt
@@ -454,6 +454,7 @@ class GameWebSocketHandlerTest {
 
             val payload1 = decodePayload(response1, GameJoinedPayload.serializer())
 
+            assertEquals("game-1", payload1.gameId)
             assertEquals("player-1", payload1.playerId)
             assertEquals(state, payload1.state)
             assertEquals(state.createViewForPlayer("player-1"), payload1.stateView)

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/enums/GameErrorReason.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/enums/GameErrorReason.kt
@@ -53,4 +53,47 @@ enum class GameErrorReason {
     CANNOT_SPY_WITHOUT_MONEY,
     CANNOT_CATCH_WHILE_SPYING,
     NOT_SPIED_UPON,
+    ;
+
+    /**
+     * Returns a human-readable message for this error reason.
+     */
+    fun toUserMessage(): String =
+        when (this) {
+            INTERNAL_SERVER_ERROR -> "An unexpected server error occurred."
+            INVALID_MESSAGE_FORMAT, UNSUPPORTED_MESSAGE_TYPE, MISSING_PAYLOAD, INVALID_PAYLOAD ->
+                "Invalid communication with server."
+            CONNECTION_ALREADY_BOUND -> "You are already connected to a game."
+            CONNECTION_NOT_BOUND -> "Connection lost. Please try again."
+            GAME_NOT_FOUND -> "Game not found. Please check the code."
+            PLAYER_NOT_IN_GAME -> "You are not a member of this game."
+            INVALID_RECONNECTION_TOKEN -> "Session expired. Please rejoin."
+            INVALID_PHASE -> "This action is not allowed right now."
+            UNKNOWN_ACTOR -> "Invalid player action."
+            NOT_YOUR_TURN -> "It is not your turn."
+            ALREADY_IN_ROOM -> "You are already in this room."
+            NOT_ENOUGH_PLAYERS -> "Not enough players to start."
+            ROOM_FULL -> "The room is full."
+            NOT_HOST -> "Only the host can perform this action."
+            INVALID_PLAYER_NAME -> "Invalid player name."
+            DECK_EMPTY -> "The deck is empty."
+            OWN_AUCTION -> "You cannot bid on your own auction."
+            EXCLUDED_FROM_AUCTION -> "You are excluded from this auction."
+            BID_TOO_LOW -> "Your bid is too low."
+            BID_TOO_HIGH -> "Your bid is higher than your money."
+            NOT_ENOUGH_MONEY -> "You do not have enough money."
+            NOT_AUCTIONEER -> "You are not the auctioneer."
+            UNKNOWN_TARGET -> "Target player not found."
+            TARGETING_SELF -> "You cannot target yourself."
+            INITIATOR_MISSING_ANIMAL -> "You don't have the required animal."
+            TARGET_MISSING_ANIMAL -> "Target player doesn't have the required animal."
+            NOT_OWNED_MONEY_CARDS -> "You don't own these money cards."
+            NOT_TRADE_INITIATOR -> "You are not the trade initiator."
+            NOT_TRADE_TARGET -> "You are not the trade target."
+            ACTIVE_PLAYER_CANNOT_SPY -> "The active player cannot spy."
+            ALREADY_SPIED_THIS_TURN -> "You already spied this turn."
+            CANNOT_SPY_WITHOUT_MONEY -> "You need at least one money card to spy."
+            CANNOT_CATCH_WHILE_SPYING -> "You cannot catch a spy while spying."
+            NOT_SPIED_UPON -> "You were not spied upon."
+        }
 }

--- a/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
+++ b/shared/src/main/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketPayloads.kt
@@ -48,6 +48,7 @@ data class JoinGamePayload(
  */
 @Serializable
 data class GameJoinedPayload(
+    val gameId: String,
     val playerId: String,
     val reconnectToken: String,
     val state: GameState,

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/enums/GameErrorReasonTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/enums/GameErrorReasonTest.kt
@@ -1,5 +1,6 @@
 package at.aau.kuhhandel.shared.enums
 
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -9,6 +10,22 @@ class GameErrorReasonTest {
         assertEquals(
             "EXCLUDED_FROM_AUCTION",
             GameErrorReason.EXCLUDED_FROM_AUCTION.name,
+        )
+    }
+
+    @Test
+    fun `all error reasons provide a non-empty user message`() {
+        GameErrorReason.entries.forEach { reason ->
+            val message = reason.toUserMessage()
+            assertTrue(message.isNotEmpty(), "Message for $reason should not be empty")
+        }
+    }
+
+    @Test
+    fun `GAME_NOT_FOUND provides expected message`() {
+        assertEquals(
+            "Game not found. Please check the code.",
+            GameErrorReason.GAME_NOT_FOUND.toUserMessage(),
         )
     }
 }

--- a/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
+++ b/shared/src/test/kotlin/at/aau/kuhhandel/shared/websocket/WebSocketProtocolTest.kt
@@ -102,6 +102,7 @@ class WebSocketProtocolTest {
     fun `GameJoinedPayload round-trips`() {
         val payload =
             GameJoinedPayload(
+                gameId = "game-1",
                 playerId = "player-1",
                 reconnectToken = "token-1",
                 state = GameState(),


### PR DESCRIPTION
# PR Description: UI/UX Polish and Join/Creation Robustness

This PR addresses several UI/UX polish tasks and improves the architectural robustness of the game joining and creation flows. It introduces a protocol synchronization update between the server and client to ensure state consistency.

## Summary of Changes

###  Robust Join/Creation Flow (Protocol & Server)
*   **Protocol Update**: Updated `GameJoinedPayload` in the `:shared` module to include the `gameId` field. This aligns the join response with the existing `GameCreatedPayload` pattern.
*   **Server Implementation**: Modified `handleJoinGame` in `GameWebSocketHandler.kt` to explicitly populate the `gameId` in the success response, ensuring the client receives definitive confirmation of the room entry.
*   **Client Synchronization**: Refactored `GameRepository.kt` to remove "optimistic" state updates. The client now waits for the server's authoritative `GAME_JOINED` or `GAME_CREATED` message before updating its internal `gameId`.
*   **Navigation Safety**: Updated `LobbyJoiningViewModel.kt` to trigger navigation only when both `gameId` and `gameState` are confirmed by the server, effectively preventing "ghost lobbies" when an invalid game code is provided.

###  Enhanced Error Handling
*   **Human-Readable Messages**: Introduced a `toUserMessage()` extension function for `GameErrorReason` in the `:shared` module, mapping technical error codes (enums) to user-friendly strings.
*   **Client-Side Mapping**: `GameRepository.kt` now automatically transforms technical WebSocket error strings (e.g., `GAME_NOT_FOUND`) into localized messages (e.g., *"Game not found. Please check the code."*) before updating the UI state.

###  UI/UX Polishing
*   **Lobby Player Highlighting**: 
    *   Added an `isMe` flag to `PlayerDisplayItem`, determined by comparing the player ID with the local session ID.
    *   Updated `LobbyScreen.kt` to visually distinguish the local player using a 2dp `DefaultPurple` border, a `WhitePurple` background, and a dedicated **"(You)"** badge next to the name.
*   **Creation Feedback Delay**: Implemented a 500ms transition delay in `RoomCreationScreen.kt` following successful room creation. This ensures the host has sufficient time to register the "Lobby created!" confirmation and the generated room code before the UI transitions to the player list.
