### PR TITLE
chore: isolate staging onto its own Postgres schema

### DIFF
--- a/deploy/k8s/overlays/staging/app/spring-profile-patch.yaml
+++ b/deploy/k8s/overlays/staging/app/spring-profile-patch.yaml
@@ -1,7 +1,8 @@
-# Diese Datei überschreibt nur das Spring-Profil für Staging.
-#
-# Die App-Basis bleibt gleich, aber der Container startet mit
-# `SPRING_PROFILES_ACTIVE=staging`.
+# Staging-spezifische Deployment-Overrides gegenüber der gemeinsamen App-Basis:
+#   - SPRING_PROFILES_ACTIVE=staging
+#   - eigene erlaubte WebSocket-Origins
+#   - eigenes Postgres-Schema `staging` (staging teilt die DB mit prod, schreibt aber
+#     in ein getrenntes Schema, damit sich beide nicht auf denselben Zeilen stören)
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -16,3 +17,7 @@ spec:
               value: staging
             - name: KUHHANDEL_WEBSOCKET_ALLOWED_ORIGINS
               value: "https://staging-k3s-api.se-aau.com,https://staging-api.se-aau.com"
+            # Staging teilt sich die Supabase-DB mit prod. Eigenes Postgres-Schema, damit
+            # beide nicht auf denselben Zeilen kollidieren (prod bleibt auf `public`).
+            - name: SPRING_DATASOURCE_HIKARI_SCHEMA
+              value: staging


### PR DESCRIPTION
## Was
Setzt am **staging**-Overlay `SPRING_DATASOURCE_HIKARI_SCHEMA=staging`, damit die staging-Umgebung in ein eigenes Postgres-Schema `staging` schreibt statt in `public`.

## Warum
Staging und Production teilen sich **eine** Supabase-DB. Beide Sweeper laufen über dieselben `games`-Zeilen. Prods alte `v1.1.0`-Logik wickelt staging-Auktionen falsch ab und crasht an der neuen Phase (`No enum constant GamePhase.AUCTION_PAYMENT`) → Auktionen werden auf staging nicht-deterministisch übersprungen. Mit eigenem Schema sehen sich die beiden Umgebungen nicht mehr.

## Effekt
- **Staging** → Schema `staging` (in Supabase bereits angelegt; `ddl-auto` baut die Tabellen beim nächsten Boot frisch dort, inkl. korrektem `phase`-Check mit `AUCTION_PAYMENT`).
- **Production** → unverändert auf `public` (production-Overlay bekommt diesen Env nicht).

## Nach dem Merge
Flux startet den staging-Pod neu. Verifizieren: Supabase-Schema-Dropdown → `staging` (Tabellen erscheinen), dann Auktion auf staging spielen — keine übersprungene Entscheidung mehr.